### PR TITLE
ci: Add rule for deploy stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,9 @@ artifactory:
       artifacts: true
     - job: coverage
     - job: pre-commit
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 
 include:
   - project: "se-toolchain/ci-templates-docker"


### PR DESCRIPTION
This rule should let the deploy stage trigger when ever a new tag is pulled from GitHub.