### PR TITLE
fix: do not add dependencies in wheel.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,9 +12,8 @@ stages:
 wheel:
   stage: build
   extends: .wheel
-  script:
+  before_script:
     - *patch-pyproject-toml
-    - pip wheel . -w dist/
 
 pages:
   stage: build


### PR DESCRIPTION
As we build the polarion-rest-api-client now separately, there is no need to include dependencies in the wheel anymore.