### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.2
+    rev: v1.7.5
     hooks:
       - id: docformatter
         additional_dependencies:
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - pydocstyle[toml]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.5.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -97,10 +97,10 @@ repos:
           - --comment-style
           - "..|  |"
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v2.1.0
     hooks:
       - id: reuse
   - repo: https://github.com/qoomon/git-conventional-commits
-    rev: v2.6.4
+    rev: v2.6.5
     hooks:
       - id: conventional-commits


### PR DESCRIPTION
Also switch to the pre-commit black mirror, which runs about 2x faster.
