### PR TITLE
Avoid dirtying the worktree

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Add git PAT
         run: |-
           git config --global --add url."https://${{ secrets.PAT_GITHUB }}@github".insteadOf https://github
+      - name: Pre-install private Github dependencies
+        run: |-
+          python -m pip install git+https://github.com/DSD-DBS/polarion-rest-api-client.git@v0.2.1
       - name: Install test dependencies
         run: |-
           python -m pip install '.[test]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,14 +6,9 @@ stages:
   - test
   - deploy
 
-.patch-pyproject-toml: &patch-pyproject-toml
-  - sed -i -e 's/\(^  "polarion-rest-api-client\).*",/\1",/' pyproject.toml
-
 wheel:
   stage: build
   extends: .wheel
-  before_script:
-    - *patch-pyproject-toml
 
 pages:
   stage: build
@@ -22,8 +17,6 @@ pages:
     OUTPUT_DIR: public
     SPHINX_DEPENDENCIES: ".[docs]"
   only: [main]
-  before_script:
-    - *patch-pyproject-toml
 
 pages:test:
   extends: pages
@@ -31,8 +24,6 @@ pages:test:
     OUTPUT_DIR: pages-test
   only: []
   except: [main]
-  before_script:
-    - *patch-pyproject-toml
 
 coverage:
   stage: test
@@ -40,15 +31,11 @@ coverage:
   variables:
     COVERAGE_SOURCE: capella2polarion
   needs: []
-  before_script:
-    - *patch-pyproject-toml
 
 pre-commit:
   stage: test
   extends: .pre-commit
   needs: []
-  before_script:
-    - *patch-pyproject-toml
 
 artifactory:
   stage: deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "capellambse",
   "click",
   "PyYAML",
-  "polarion-rest-api-client @ git+https://github.com/DSD-DBS/polarion-rest-api-client.git@v0.2.1",
+  "polarion-rest-api-client==0.2.1",
   "requests",
 ]
 


### PR DESCRIPTION
Patching the pyproject.toml file like before led to a dirty worktree, which caused setuptools-scm to always generate dev versions even when making wheels for a tag.

This commit refactors the CI so that patching the pyproject.toml file is no longer necessary. The (yet) private dependency project will be install directly from the Github repository as additional step before installing the rest of the test dependencies, and the Gitlab pipelines don't need to do anything special because they pull from an internal repository which hosts the dependency package.