### PR TITLE
Linked Text Styling

### DIFF
--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -105,7 +105,7 @@ def _condition(
     _type = "text/html" if html else "text/plain"
     return {
         "type": _type,
-        "value": f'<span style="text-align: center;">{value}</span>',
+        "value": f'<div style="text-align: center;">{value}</div>',
     }
 
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1101,11 +1101,11 @@ class TestSerializers:
                     "additional_attributes": {
                         "preCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;"></span>',
+                            "value": '<div style="text-align: center;"></div>',
                         },
                         "postCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;"></span>',
+                            "value": '<div style="text-align: center;"></div>',
                         },
                     },
                 },
@@ -1174,11 +1174,11 @@ class TestSerializers:
                     "additional_attributes": {
                         "preCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;">hehe<br/></span>',
+                            "value": '<div style="text-align: center;">hehe<br/></div>',
                         },
                         "postCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;"></span>',
+                            "value": '<div style="text-align: center;"></div>',
                         },
                     },
                 },
@@ -1196,11 +1196,11 @@ class TestSerializers:
                     "additional_attributes": {
                         "preCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;"></span>',
+                            "value": '<div style="text-align: center;"></div>',
                         },
                         "postCondition": {
                             "type": "text/html",
-                            "value": '<span style="text-align: center;"></span>',
+                            "value": '<div style="text-align: center;"></div>',
                         },
                     },
                 },


### PR DESCRIPTION
Currently we loose much of the styling of linked texts. Especially for Pre- and Postconditions we do not generate links for linked elements such as states, we don't strike through deleted work items and we loose line breaks. In addition conditions seem to be aligned centered in Capella but they aren't in Polarion. All this should be fixed by this PR and we also do some minor refactoring to use the same functionality in the `linked_text_as_description` serializer and give the `CapellaWorkItemSerializer` class a bit more structure
resolves #49 