### PR TITLE
feat: Add exit codes to __main__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - capellambse==0.6.1
           - types-requests
           - types-PyYAML
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/capella2polarion/converters/data_session.py
+++ b/capella2polarion/converters/data_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 
-from capellambse.model import common, diagram
+from capellambse import model as m
 
 from capella2polarion import data_models as dm
 from capella2polarion.converters import converter_config
@@ -17,7 +17,7 @@ class ConverterData:
 
     layer: str
     type_config: converter_config.CapellaTypeConfig
-    capella_element: diagram.Diagram | common.GenericElement
+    capella_element: m.Diagram | m.GenericElement
     work_item: dm.CapellaWorkItem | None = None
     description_references: list[str] = dataclasses.field(default_factory=list)
     errors: set[str] = dataclasses.field(default_factory=set)

--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -18,9 +18,8 @@ import jinja2
 import markupsafe
 import polarion_rest_api_client as polarion_api
 from capellambse import helpers as chelpers
-from capellambse.model import common
-from capellambse.model.crosslayer import interaction
-from capellambse.model.layers import oa
+from capellambse import model as m
+from capellambse.metamodel import interaction, oa
 from lxml import etree
 
 from capella2polarion import data_models
@@ -167,7 +166,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
 
     def _draw_diagram_svg(
         self,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         file_name: str,
         title: str,
         max_width: int,
@@ -236,7 +235,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
     def __insert_diagram(
         self,
         work_item: data_models.CapellaWorkItem,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         file_name: str,
         render_params: dict[str, t.Any] | None = None,
         max_width: int = 800,
@@ -272,7 +271,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
     def _draw_additional_attributes_diagram(
         self,
         work_item: data_models.CapellaWorkItem,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         attribute: str,
         title: str,
         render_params: dict[str, t.Any] | None = None,
@@ -294,7 +293,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         }
 
     def _sanitize_linked_text(
-        self, obj: common.GenericElement
+        self, obj: m.GenericElement
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -311,7 +310,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         return self._sanitize_text(obj, linked_text)
 
     def _sanitize_text(
-        self, obj: common.GenericElement, text: markupsafe.Markup | str
+        self, obj: m.GenericElement, text: markupsafe.Markup | str
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -402,7 +401,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
 
     def _get_requirement_types_text(
         self,
-        obj: common.GenericElement,
+        obj: m.GenericElement,
     ) -> dict[str, dict[str, str]]:
         type_texts = collections.defaultdict(list)
         for req in getattr(obj, "requirements", []):

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -10,9 +10,8 @@ from collections import defaultdict
 
 import capellambse
 import polarion_rest_api_client as polarion_api
-from capellambse.model import common
-from capellambse.model import diagram as diag
-from capellambse.model.crosslayer import fa
+from capellambse import model as m
+from capellambse.metamodel import fa
 
 import capella2polarion.converters.polarion_html_helper
 from capella2polarion import data_models
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 TYPE_RESOLVERS = {"Part": lambda obj: obj.type.uuid}
 _Serializer: t.TypeAlias = cabc.Callable[
-    [common.GenericElement, str, str, str, dict[str, t.Any]],
+    [m.GenericElement, str, str, str, dict[str, t.Any]],
     list[polarion_api.WorkItemLink],
 ]
 
@@ -76,7 +75,7 @@ class LinkSerializer:
                 else:
                     refs = _resolve_attribute(obj, attr_id)
                     new: cabc.Iterable[str]
-                    if isinstance(refs, common.ElementList):
+                    if isinstance(refs, m.ElementList):
                         new = refs.by_uuid  # type: ignore[assignment]
                     else:
                         assert hasattr(refs, "uuid"), "No 'uuid' on value"
@@ -134,7 +133,7 @@ class LinkSerializer:
 
     def _handle_description_reference_links(
         self,
-        obj: common.GenericElement,
+        obj: m.GenericElement,
         work_item_id: str,
         role_id: str,
         attr_id: str,
@@ -147,7 +146,7 @@ class LinkSerializer:
 
     def _handle_diagram_reference_links(
         self,
-        obj: diag.Diagram,
+        obj: m.Diagram,
         work_item_id: str,
         role_id: str,
         attr_id: str,
@@ -170,7 +169,7 @@ class LinkSerializer:
 
     def _collect_uuids(
         self,
-        nodes: cabc.Iterable[common.GenericElement],
+        nodes: cabc.Iterable[m.GenericElement],
     ) -> cabc.Iterator[str]:
         type_resolvers = TYPE_RESOLVERS
         for node in nodes:
@@ -301,7 +300,7 @@ class LinkSerializer:
                             obj._short_repr_(),
                         )
 
-                    if isinstance(attr, common.ElementList):
+                    if isinstance(attr, m.ElementList):
                         uuids = attr.by_uuid  # type: ignore[assignment]
                     else:
                         assert hasattr(attr, "uuid")
@@ -389,12 +388,12 @@ def _sorted_unordered_html_list(
 
 
 def _resolve_attribute(
-    obj: common.GenericElement, attr_id: str
-) -> common.ElementList[common.GenericElement] | common.GenericElement:
+    obj: m.GenericElement, attr_id: str
+) -> m.ElementList[m.GenericElement] | m.GenericElement:
     attr_name, _, map_id = attr_id.partition(".")
     objs = getattr(obj, attr_name)
     if map_id:
-        if isinstance(objs, common.GenericElement):
+        if isinstance(objs, m.GenericElement):
             return _resolve_attribute(objs, map_id)
         objs = objs.map(map_id)
     return objs

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import pathlib
 import re
 
-import capellambse
 import jinja2
 from capellambse import helpers as chelpers
+from capellambse import model as m
 from lxml import etree, html
 
 heading_id_prefix = "polarion_wiki macro name=module-workitem;params=id="
@@ -80,11 +80,7 @@ class JinjaRendererMixin:
 
     def check_model_element(
         self, obj: object
-    ) -> (
-        capellambse.model.GenericElement
-        | capellambse.model.diagram.AbstractDiagram
-        | None
-    ):
+    ) -> m.GenericElement | m.AbstractDiagram | None:
         """Check if a model element was passed.
 
         Return None if no element and raise a TypeError if a wrong typed
@@ -94,15 +90,9 @@ class JinjaRendererMixin:
         if jinja2.is_undefined(obj) or obj is None:
             return None
 
-        if isinstance(obj, capellambse.model.ElementList):
+        if isinstance(obj, m.ElementList):
             raise TypeError("Cannot make an href to a list of elements")
-        if not isinstance(
-            obj,
-            (
-                capellambse.model.GenericElement,
-                capellambse.model.diagram.AbstractDiagram,
-            ),
-        ):
+        if not isinstance(obj, (m.GenericElement, m.AbstractDiagram)):
             raise TypeError(f"Expected a model object, got {obj!r}")
         return obj
 

--- a/capella2polarion/errors_and_warnings_report.j2
+++ b/capella2polarion/errors_and_warnings_report.j2
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Log Report</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h1 {
+            color: #333;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            padding: 10px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background-color: #f4f4f4;
+        }
+        .warning {
+            background-color: #fff3cd;
+        }
+        .error {
+            background-color: #f8d7da;
+        }
+    </style>
+</head>
+<body>
+    <h1>Errors and Warnings</h1>
+
+    <h2>Errors</h2>
+    {% for module, errors in messages.errors.items() %}
+    <h3>Module: {{ module }}</h3>
+    <table>
+        <tr>
+            <th>Function</th>
+            <th>Message</th>
+        </tr>
+        {% for error in errors %}
+        <tr class="error">
+            <td>{{ error.keys() | list | first }}</td>
+            <td>{{ error.values() | list | first }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endfor %}
+
+    <h2>Warnings</h2>
+    {% for module, warnings in messages.warnings.items() %}
+    <h3>Module: {{ module }}</h3>
+    <table>
+        <tr>
+            <th>Function</th>
+            <th>Message</th>
+        </tr>
+        {% for warning in warnings %}
+        <tr class="warning">
+            <td>{{ warning.keys() | list | first }}</td>
+            <td>{{ warning.values() | list | first }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endfor %}
+</body>
+
+</html>

--- a/ci-templates/gitlab/synchronise_elements_with_exit_codes.yml
+++ b/ci-templates/gitlab/synchronise_elements_with_exit_codes.yml
@@ -1,0 +1,29 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+variables:
+  CAPELLA2POLARION_DEBUG: "1"
+
+capella2polarion_synchronise_elements:
+  allow_failure:
+    exit_codes:
+      - 2
+
+  needs:
+    - job: update_capella_diagram_cache
+      artifacts: true
+
+  script:
+    - pip install capella2polarion --pre
+    - >
+      python \
+        -m capella2polarion \
+        $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
+        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
+        --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
+        --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
+        --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
+        --type-prefix="${CAPELLA2POLARION_TYPE_PREFIX:?}" \
+        --role-prefix="${CAPELLA2POLARION_ROLE_PREFIX:?}" \
+         --determine-exit-code-from-logs \
+        synchronize

--- a/ci-templates/gitlab/synchronise_elements_with_exit_codes.yml
+++ b/ci-templates/gitlab/synchronise_elements_with_exit_codes.yml
@@ -19,11 +19,11 @@ capella2polarion_synchronise_elements:
       python \
         -m capella2polarion \
         $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
-        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
         --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
         --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
+        --determine-exit-code-from-logs \
+        synchronize \
         --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
-        --type-prefix="${CAPELLA2POLARION_TYPE_PREFIX:?}" \
-        --role-prefix="${CAPELLA2POLARION_ROLE_PREFIX:?}" \
-         --determine-exit-code-from-logs \
-        synchronize
+        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
+        ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
+        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"}

--- a/jupyter-notebooks/document_templates/test-classes.html.j2
+++ b/jupyter-notebooks/document_templates/test-classes.html.j2
@@ -27,6 +27,6 @@
 {{ heading(1, "Class Document", session)}}
 {{ add_class_dependencies(cls, classes) }}
 {{ heading(2, "Data Classes", session)}}
-{% for cl in classes | unique %}
+{% for cl in classes | unique(attribute="uuid") %}
 {{ insert_work_item(cl, session) }}
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "capellambse>=0.5,<0.6",
+  "capellambse>=0.6.1,<0.7",
   "capellambse_context_diagrams",
   "click",
   "PyYAML",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import capellambse
 import markupsafe
 import polarion_rest_api_client as polarion_api
 import pytest
+from capellambse import model as m
 
 from capella2polarion import cli, data_models
 from capella2polarion.connectors import polarion_repo, polarion_worker
@@ -77,7 +78,7 @@ class FakeModelObject(mock.MagicMock):
         name: str = "",
         attribute: t.Any | None = None,
     ):
-        super().__init__(spec=capellambse.model.GenericElement)
+        super().__init__(spec=m.GenericElement)
         self.uuid = uuid
         self.name = name
         self.attribute = attribute

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,9 @@ from .conftest import (  # type: ignore[import]
 )
 
 
-def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
+def test_migrate_model_elements(
+    monkeypatch: pytest.MonkeyPatch, flaggs: list[str]
+):
     mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
     monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
     mock_get_polarion_wi_map = mock.MagicMock()
@@ -54,7 +56,7 @@ def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
         "--polarion-url",
         "https://www.czy.de",
         "--polarion-pat",
-        "AlexandersPrivateAcessToken",
+        "PrivateAcessToken",
         "--polarion-delete-work-items",
         "--capella-model",
         json.dumps(TEST_MODEL),
@@ -71,3 +73,66 @@ def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
     assert mock_delete_work_items.call_count == 1
     assert mock_patch_work_items.call_count == 1
     assert mock_post_work_items.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "exit_code",
+    [
+        pytest.param([0], id="Successful"),
+        pytest.param([1], id="Failure"),
+        pytest.param([2], id="Warning"),
+    ],
+)
+def test_migrate_model_elements_with_exit_codes_determined_from_logging(
+    monkeypatch: pytest.MonkeyPatch, exit_code: int
+):
+    def log_from_exit_code(exit_code: int):
+        if exit_code == 0:
+            main.logger.info("This is an info message.")
+        elif exit_code == 1:
+            main.logger.error("This is an error message.")
+        elif exit_code == 2:
+            main.logger.warning("This is a warning message.")
+
+    mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
+    monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
+    mock_get_polarion_wi_map = mock.MagicMock()
+    monkeypatch.setattr(
+        CapellaPolarionWorker,
+        "load_polarion_work_item_map",
+        mock_get_polarion_wi_map,
+    )
+    mock_delete_work_items = mock.MagicMock(
+        side_effect=lambda *_, **__: log_from_exit_code(exit_code)
+    )
+    monkeypatch.setattr(
+        CapellaPolarionWorker, "delete_work_items", mock_delete_work_items
+    )
+    mock_post_work_items = mock.MagicMock()
+    monkeypatch.setattr(
+        CapellaPolarionWorker, "post_work_items", mock_post_work_items
+    )
+    mock_patch_work_items = mock.MagicMock()
+    monkeypatch.setattr(
+        CapellaPolarionWorker, "patch_work_items", mock_patch_work_items
+    )
+
+    command: list[str] = [
+        "--polarion-project-id",
+        "{project-id}",
+        "--polarion-url",
+        "https://www.czy.de",
+        "--polarion-pat",
+        "PrivateAcessToken",
+        "--polarion-delete-work-items",
+        "--capella-model",
+        json.dumps(TEST_MODEL),
+        "--synchronize-config",
+        str(TEST_MODEL_ELEMENTS_CONFIG),
+        "--determine-exit-code-from-logs",
+        "synchronize",
+    ]
+
+    result = testing.CliRunner().invoke(main.cli, command, terminal_width=60)
+
+    assert result.exit_code == exit_code

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -12,7 +12,7 @@ import capellambse_context_diagrams.context
 import markupsafe
 import polarion_rest_api_client as polarion_api
 import pytest
-from capellambse.model import common
+from capellambse import model as m
 
 from capella2polarion import data_models
 from capella2polarion.connectors import polarion_repo
@@ -567,7 +567,7 @@ class TestModelElements:
         obj = FakeModelObject(
             "uuid6",
             name="Fake 6",
-            attribute=common.ElementList(
+            attribute=m.ElementList(
                 base_object.c2pcli.capella_model,
                 [fake, fake1],
                 FakeModelObject,


### PR DESCRIPTION
The exit codes are determined from the logs. If there is one warning the exit code 2 is used. If there is at least one error logged -> exit code 1. If only debug and info is logged exit code 0 is used.

This can be enabled with the flag `--determine-exit-code-from-logs`.