### PR TITLE
Constrain capellambse to v0.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "capellambse",
+  "capellambse>=0.5,<0.6",
   "capellambse_context_diagrams",
   "click",
   "PyYAML",


### PR DESCRIPTION
This should make transitioning to v0.6.x a bit smoother.