### PR TITLE
Fix link generation

### DIFF
--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -393,8 +393,8 @@ def _resolve_attribute(
 ) -> common.ElementList[common.GenericElement] | common.GenericElement:
     attr_name, _, map_id = attr_id.partition(".")
     objs = getattr(obj, attr_name)
-    if isinstance(objs, common.GenericElement):
-        return _resolve_attribute(objs, map_id)
     if map_id:
+        if isinstance(objs, common.GenericElement):
+            return _resolve_attribute(objs, map_id)
         objs = objs.map(map_id)
     return objs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def dummy_work_items() -> dict[str, data_models.CapellaWorkItem]:
     }
 
 
-class FakeModelObject:
+class FakeModelObject(mock.MagicMock):
     """Mimicks a capellambse model objectyping."""
 
     def __init__(
@@ -77,6 +77,7 @@ class FakeModelObject:
         name: str = "",
         attribute: t.Any | None = None,
     ):
+        super().__init__(spec=capellambse.model.GenericElement)
         self.uuid = uuid
         self.name = name
         self.attribute = attribute


### PR DESCRIPTION
We experienced really many errors in Pipelines when generating parent links. This is due to an error which was introduced when we wanted to support nested links for single items [here](https://github.com/DSD-DBS/capella-polarion/blame/e39f922581a706e589ff98e1f5887af1683dfe7a/capella2polarion/converters/link_converter.py#L396). Unfortunately our tests did not fail here, because we check whether the element is a `GenericElement`, but we use the `FakeModelElement` class to perform our tests.
This PR first changed this `FakeModelElement` class to be a MagicMock of `GenericElement` which made 3 tests fail. All these tests are fixed by a minor change in the link resolver