### PR TITLE
Upgrade to capellambse v0.6.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         additional_dependencies:
           - bidict
           - cairosvg
-          - capellambse==0.5.69
+          - capellambse==0.6.6
           - click
           - jinja2
           - polarion-rest-api-client==1.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
           - capellambse==0.6.6
           - click
           - jinja2
-          - polarion-rest-api-client==1.1.2
+          - polarion-rest-api-client==1.1.3
           - pydantic
           - types-requests
           - types-PyYAML

--- a/capella2polarion/converters/converter_config.py
+++ b/capella2polarion/converters/converter_config.py
@@ -9,7 +9,7 @@ import typing as t
 from collections import abc as cabc
 
 import yaml
-from capellambse.model import common, diagram
+from capellambse import model as m
 from capellambse_context_diagrams import filters as context_filters
 
 logger = logging.getLogger(__name__)
@@ -370,11 +370,11 @@ def _filter_context_diagram_config(
 def _filter_links(
     c_type: str, links: list[LinkConfig], is_global: bool = False
 ) -> list[LinkConfig]:
-    c_class: type[common.ModelObject | diagram.Diagram]
+    c_class: type[m.ModelObject]
     if c_type == "diagram":
-        c_class = diagram.Diagram
+        c_class = m.Diagram
     else:
-        if not (c_classes := common.find_wrapper(c_type)):
+        if not (c_classes := m.find_wrapper(c_type)):
             logger.error("Did not find any matching Wrapper for %r", c_type)
             return links
         c_class = c_classes[0]
@@ -385,7 +385,7 @@ def _filter_links(
         is_diagram_elements = capella_attr == DIAGRAM_ELEMENTS_SERIALIZER
         if (
             capella_attr == DESCRIPTION_REFERENCE_SERIALIZER
-            or (is_diagram_elements and c_class == diagram.Diagram)
+            or (is_diagram_elements and c_class == m.Diagram)
             or hasattr(c_class, capella_attr)
         ):
             available_links.append(link)

--- a/capella2polarion/converters/data_session.py
+++ b/capella2polarion/converters/data_session.py
@@ -17,7 +17,7 @@ class ConverterData:
 
     layer: str
     type_config: converter_config.CapellaTypeConfig
-    capella_element: m.ModelElement
+    capella_element: m.ModelElement | m.Diagram
     work_item: dm.CapellaWorkItem | None = None
     description_references: list[str] = dataclasses.field(default_factory=list)
     errors: set[str] = dataclasses.field(default_factory=set)

--- a/capella2polarion/converters/data_session.py
+++ b/capella2polarion/converters/data_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 
-from capellambse.model import common, diagram
+from capellambse import model as m
 
 from capella2polarion import data_models as dm
 from capella2polarion.converters import converter_config
@@ -17,7 +17,7 @@ class ConverterData:
 
     layer: str
     type_config: converter_config.CapellaTypeConfig
-    capella_element: diagram.Diagram | common.GenericElement
+    capella_element: m.ModelElement
     work_item: dm.CapellaWorkItem | None = None
     description_references: list[str] = dataclasses.field(default_factory=list)
     errors: set[str] = dataclasses.field(default_factory=set)

--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -19,7 +19,6 @@ import markupsafe
 import polarion_rest_api_client as polarion_api
 from capellambse import helpers as chelpers
 from capellambse import model as m
-from capellambse.model import diagram as diag
 from lxml import etree
 
 from capella2polarion import data_models
@@ -284,7 +283,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         }
 
     def _sanitize_linked_text(
-        self, obj: m.ModelObject
+        self, obj: m.ModelElement | m.Diagram
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -301,7 +300,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         return self._sanitize_text(obj, linked_text)
 
     def _sanitize_text(
-        self, obj: m.ModelObject, text: markupsafe.Markup | str
+        self, obj: m.ModelElement | m.Diagram, text: markupsafe.Markup | str
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -391,7 +390,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         return match.group(default_group)
 
     def _get_requirement_types_text(
-        self, obj: m.ModelObject
+        self, obj: m.ModelElement | m.Diagram
     ) -> dict[str, dict[str, str]]:
         type_texts = collections.defaultdict(list)
         for req in getattr(obj, "requirements", []):
@@ -452,7 +451,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         """Serialize a diagram for Polarion."""
         diagram = converter_data.capella_element
         assert converter_data.work_item is not None
-        assert isinstance(diagram, diag.Diagram)
+        assert isinstance(diagram, m.Diagram)
         work_item_id = converter_data.work_item.id
 
         diagram_html, attachment = self._draw_diagram_svg(
@@ -480,7 +479,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         obj = converter_data.capella_element
         assert hasattr(obj, "precondition"), "Missing PreCondition Attribute"
         assert hasattr(obj, "postcondition"), "Missing PostCondition Attribute"
-        assert not isinstance(obj, diag.Diagram)
+        assert not isinstance(obj, m.Diagram)
 
         def get_condition(cap: m.ModelElement, name: str) -> str:
             if not (condition := getattr(cap, name)):

--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -18,7 +18,7 @@ import jinja2
 import markupsafe
 import polarion_rest_api_client as polarion_api
 from capellambse import helpers as chelpers
-from capellambse.model import common
+from capellambse import model as m
 from capellambse.model import diagram as diag
 from lxml import etree
 
@@ -156,7 +156,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
 
     def _draw_diagram_svg(
         self,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         file_name: str,
         title: str,
         max_width: int,
@@ -225,7 +225,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
     def __insert_diagram(
         self,
         work_item: data_models.CapellaWorkItem,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         file_name: str,
         render_params: dict[str, t.Any] | None = None,
         max_width: int = 800,
@@ -262,7 +262,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
     def _draw_additional_attributes_diagram(
         self,
         work_item: data_models.CapellaWorkItem,
-        diagram: capellambse.model.diagram.AbstractDiagram,
+        diagram: m.AbstractDiagram,
         attribute: str,
         title: str,
         render_params: dict[str, t.Any] | None = None,
@@ -284,7 +284,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         }
 
     def _sanitize_linked_text(
-        self, obj: common.GenericElement | diag.Diagram
+        self, obj: m.ModelObject
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -301,9 +301,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         return self._sanitize_text(obj, linked_text)
 
     def _sanitize_text(
-        self,
-        obj: common.GenericElement | diag.Diagram,
-        text: markupsafe.Markup | str,
+        self, obj: m.ModelObject, text: markupsafe.Markup | str
     ) -> tuple[
         list[str], markupsafe.Markup, list[polarion_api.WorkItemAttachment]
     ]:
@@ -393,8 +391,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         return match.group(default_group)
 
     def _get_requirement_types_text(
-        self,
-        obj: common.GenericElement | diag.Diagram,
+        self, obj: m.ModelObject
     ) -> dict[str, dict[str, str]]:
         type_texts = collections.defaultdict(list)
         for req in getattr(obj, "requirements", []):
@@ -485,7 +482,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         assert hasattr(obj, "postcondition"), "Missing PostCondition Attribute"
         assert not isinstance(obj, diag.Diagram)
 
-        def get_condition(cap: common.GenericElement, name: str) -> str:
+        def get_condition(cap: m.ModelElement, name: str) -> str:
             if not (condition := getattr(cap, name)):
                 return ""
             _, value, _ = self._sanitize_linked_text(condition)

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -10,8 +10,7 @@ from collections import defaultdict
 
 import capellambse
 import polarion_rest_api_client as polarion_api
-from capellambse.model import common
-from capellambse.model import diagram as diag
+from capellambse import model as m
 
 from capella2polarion import data_models
 from capella2polarion.connectors import polarion_repo
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 TYPE_RESOLVERS = {"Part": lambda obj: obj.type.uuid}
 _Serializer: t.TypeAlias = cabc.Callable[
-    [diag.Diagram | common.GenericElement, str, str, dict[str, t.Any]],
+    [m.ModelObject, str, str, dict[str, t.Any]],
     list[polarion_api.WorkItemLink],
 ]
 
@@ -73,7 +72,7 @@ class LinkSerializer:
                 else:
                     refs = _resolve_attribute(obj, link_config.capella_attr)
                     new: cabc.Iterable[str]
-                    if isinstance(refs, common.ElementList):
+                    if isinstance(refs, m.ElementList):
                         new = refs.by_uuid  # type: ignore[assignment]
                     elif refs is None:
                         logger.info(
@@ -140,23 +139,24 @@ class LinkSerializer:
 
     def _handle_description_reference_links(
         self,
-        obj: common.GenericElement | diag.Diagram,
+        obj: m.ModelObject,
         work_item_id: str,
         role_id: str,
         links: dict[str, polarion_api.WorkItemLink],
     ) -> list[polarion_api.WorkItemLink]:
+        assert isinstance(obj, m.ModelElement)
         refs = self.converter_session[obj.uuid].description_references
         ref_set = set(self._get_work_item_ids(work_item_id, refs, role_id))
         return self._create(work_item_id, role_id, ref_set, links)
 
     def _handle_diagram_reference_links(
         self,
-        diagram: common.GenericElement | diag.Diagram,
+        diagram: m.ModelObject,
         work_item_id: str,
         role_id: str,
         links: dict[str, polarion_api.WorkItemLink],
     ) -> list[polarion_api.WorkItemLink]:
-        assert isinstance(diagram, diag.Diagram)
+        assert isinstance(diagram, m.Diagram)
         try:
             refs = set(self._collect_uuids(diagram.nodes))
             refs = set(self._get_work_item_ids(work_item_id, refs, role_id))
@@ -173,7 +173,7 @@ class LinkSerializer:
 
     def _collect_uuids(
         self,
-        nodes: cabc.Iterable[common.GenericElement],
+        nodes: cabc.Iterable[m.ModelElement],
     ) -> cabc.Iterator[str]:
         type_resolvers = TYPE_RESOLVERS
         for node in nodes:
@@ -288,9 +288,8 @@ class LinkSerializer:
                             obj._short_repr_(),
                         )
 
-                    uuids: cabc.Iterable[str]
-                    if isinstance(attr, common.ElementList):
-                        uuids = attr.by_uuid  # type: ignore[assignment]
+                    if isinstance(attr, m.ElementList):
+                        uuids: list[str] = list(attr.by_uuid)
                     else:
                         assert hasattr(attr, "uuid")
                         uuids = [attr.uuid]
@@ -385,12 +384,12 @@ def _sorted_unordered_html_list(
 
 
 def _resolve_attribute(
-    obj: common.GenericElement | diag.Diagram, attr_id: str
-) -> common.ElementList[common.GenericElement] | common.GenericElement | None:
+    obj: m.ModelObject, attr_id: str
+) -> m.ElementList[m.ModelElement] | m.ModelElement:
     attr_name, _, map_id = attr_id.partition(".")
     objs = getattr(obj, attr_name)
     if map_id and objs is not None:
-        if isinstance(objs, common.GenericElement):
+        if isinstance(objs, m.ModelElement):
             return _resolve_attribute(objs, map_id)
         objs = objs.map(map_id)
     return objs

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 TYPE_RESOLVERS = {"Part": lambda obj: obj.type.uuid}
 _Serializer: t.TypeAlias = cabc.Callable[
-    [m.ModelObject, str, str, dict[str, t.Any]],
+    [m.ModelElement | m.Diagram, str, str, dict[str, t.Any]],
     list[polarion_api.WorkItemLink],
 ]
 
@@ -139,19 +139,18 @@ class LinkSerializer:
 
     def _handle_description_reference_links(
         self,
-        obj: m.ModelObject,
+        obj: m.ModelElement | m.Diagram,
         work_item_id: str,
         role_id: str,
         links: dict[str, polarion_api.WorkItemLink],
     ) -> list[polarion_api.WorkItemLink]:
-        assert isinstance(obj, m.ModelElement)
         refs = self.converter_session[obj.uuid].description_references
         ref_set = set(self._get_work_item_ids(work_item_id, refs, role_id))
         return self._create(work_item_id, role_id, ref_set, links)
 
     def _handle_diagram_reference_links(
         self,
-        diagram: m.ModelObject,
+        diagram: m.ModelElement | m.Diagram,
         work_item_id: str,
         role_id: str,
         links: dict[str, polarion_api.WorkItemLink],
@@ -384,7 +383,7 @@ def _sorted_unordered_html_list(
 
 
 def _resolve_attribute(
-    obj: m.ModelObject, attr_id: str
+    obj: m.ModelElement | m.Diagram, attr_id: str
 ) -> m.ElementList[m.ModelElement] | m.ModelElement:
     attr_name, _, map_id = attr_id.partition(".")
     objs = getattr(obj, attr_name)

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -75,7 +75,7 @@ class LinkSerializer:
                     if isinstance(refs, m.ElementList):
                         new = refs.by_uuid  # type: ignore[assignment]
                     elif refs is None:
-                        logger.info(
+                        logger.info(  # type: ignore[unreachable]
                             'For model element %r attribute "%s" is not set',
                             obj._short_repr_(),
                             link_config.capella_attr,

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import pathlib
 import re
 
-import capellambse
 import jinja2
 import polarion_rest_api_client as polarion_api
 from capellambse import helpers as chelpers
+from capellambse import model as m
 from lxml import html
 
 wi_id_prefix = "polarion_wiki macro name=module-workitem;params=id="
@@ -93,11 +93,7 @@ class JinjaRendererMixin:
 
     def check_model_element(
         self, obj: object
-    ) -> (
-        capellambse.model.GenericElement
-        | capellambse.model.diagram.AbstractDiagram
-        | None
-    ):
+    ) -> m.ModelElement | m.AbstractDiagram | None:
         """Check if a model element was passed.
 
         Return None if no element and raise a TypeError if a wrong typed
@@ -107,15 +103,9 @@ class JinjaRendererMixin:
         if jinja2.is_undefined(obj) or obj is None:
             return None
 
-        if isinstance(obj, capellambse.model.ElementList):
+        if isinstance(obj, m.ElementList):
             raise TypeError("Cannot make an href to a list of elements")
-        if not isinstance(
-            obj,
-            (
-                capellambse.model.GenericElement,
-                capellambse.model.diagram.AbstractDiagram,
-            ),
-        ):
+        if not isinstance(obj, (m.ModelElement, m.AbstractDiagram)):
             raise TypeError(f"Expected a model object, got {obj!r}")
         return obj
 

--- a/jupyter-notebooks/document_templates/test-classes.html.j2
+++ b/jupyter-notebooks/document_templates/test-classes.html.j2
@@ -27,6 +27,6 @@
 {{ heading(1, "Class Document", session)}}
 {{ add_class_dependencies(cls, classes) }}
 {{ heading(2, "Data Classes", session)}}
-{% for cl in classes | unique %}
+{% for cl in classes | unique(attribute="uuid") %}
 {{ insert_work_item(cl, session) }}
 {% endfor %}

--- a/jupyter-notebooks/document_templates/test-icd.html.j2
+++ b/jupyter-notebooks/document_templates/test-icd.html.j2
@@ -76,7 +76,7 @@ This interface control document defines functional interactions between the foll
 {{ heading(3, "Message Catalog", session)}}
 <p>This section identifies messages used within the interface.</p>
 {%- set classes = [] %}
-{% for ei in interface.exchange_items | unique %}
+{% for ei in interface.exchange_items | unique(attribute="uuid") %}
 {{ insert_work_item(ei, session) }}
 {% for el in ei.elements %}
 {{ add_class_dependencies(el.abstract_type, classes) }}
@@ -84,6 +84,6 @@ This interface control document defines functional interactions between the foll
 {% endfor %}
 {{ heading(3, "Message Description", session)}}
 <p>This section provides a detailed description of each message used within the interface.</p>
-{% for cl in classes | unique %}
+{% for cl in classes | unique(attribute="uuid") %}
 {{ insert_work_item(cl, session) }}
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,7 @@ description = "Synchronise Capella models with Polarion projects"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
 license = { text = "Apache-2.0" }
-authors = [
-  { name = "DB InfraGO AG" },
-]
+authors = [{ name = "DB InfraGO AG" }]
 keywords = []
 classifiers = [
   "Development Status :: 1 - Planning",
@@ -32,11 +30,11 @@ dependencies = [
   "capellambse_context_diagrams>=0.4.0",
   "click",
   "PyYAML",
-  "polarion-rest-api-client==1.1.3",
+  "polarion-rest-api-client==1.1.4",
   "bidict",
   "cairosvg",
   "jinja2",
-  "pydantic"
+  "pydantic",
 ]
 
 [project.urls]
@@ -44,21 +42,11 @@ Homepage = "https://github.com/DSD-DBS/capella2polarion"
 Documentation = "https://dsd-dbs.github.io/capella2polarion"
 
 [project.optional-dependencies]
-dev = [
-  "python-dotenv"
-]
+dev = ["python-dotenv"]
 
-docs = [
-  "furo",
-  "sphinx",
-  "sphinx-copybutton",
-  "tomli",
-]
+docs = ["furo", "sphinx", "sphinx-copybutton", "tomli"]
 
-test = [
-  "pytest",
-  "pytest-cov",
-]
+test = ["pytest", "pytest-cov"]
 
 [tool.black]
 line-length = 79
@@ -95,23 +83,21 @@ ignore_missing_imports = true
 [tool.pydocstyle]
 convention = "numpy"
 add-select = [
-  "D212",  # Multi-line docstring summary should start at the first line
-  "D402",  # First line should not be the function’s “signature”
-  "D417",  # Missing argument descriptions in the docstring
+  "D212", # Multi-line docstring summary should start at the first line
+  "D402", # First line should not be the function’s “signature”
+  "D417", # Missing argument descriptions in the docstring
 ]
 add-ignore = [
-  "D201",  # No blank lines allowed before function docstring  # auto-formatting
-  "D202",  # No blank lines allowed after function docstring  # auto-formatting
-  "D203",  # 1 blank line required before class docstring  # auto-formatting
-  "D204",  # 1 blank line required after class docstring  # auto-formatting
-  "D211",  # No blank lines allowed before class docstring  # auto-formatting
-  "D213",  # Multi-line docstring summary should start at the second line
+  "D201", # No blank lines allowed before function docstring  # auto-formatting
+  "D202", # No blank lines allowed after function docstring  # auto-formatting
+  "D203", # 1 blank line required before class docstring  # auto-formatting
+  "D204", # 1 blank line required after class docstring  # auto-formatting
+  "D211", # No blank lines allowed before class docstring  # auto-formatting
+  "D213", # Multi-line docstring summary should start at the second line
 ]
 
 [tool.pylint.master]
-extension-pkg-allow-list = [
-  "lxml.etree",
-]
+extension-pkg-allow-list = ["lxml.etree"]
 max-line-length = 79
 
 [tool.pylint.messages_control]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "capellambse>=0.5.69,<0.6",
-  "capellambse_context_diagrams>=0.3.1,<0.4",
+  "capellambse>=0.6.5,<0.7",
+  "capellambse_context_diagrams>=0.3.4",
   "click",
   "PyYAML",
   "polarion-rest-api-client==1.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "capellambse_context_diagrams>=0.4.0",
   "click",
   "PyYAML",
-  "polarion-rest-api-client==1.1.2",
+  "polarion-rest-api-client==1.1.3",
   "bidict",
   "cairosvg",
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "capellambse>=0.6.5,<0.7",
+  "capellambse>=0.6.6,<0.7",
   "capellambse_context_diagrams>=0.3.4",
   "click",
   "PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "capellambse>=0.6.6,<0.7",
-  "capellambse_context_diagrams>=0.3.4",
+  "capellambse_context_diagrams>=0.4.0",
   "click",
   "PyYAML",
   "polarion-rest-api-client==1.1.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import capellambse
 import markupsafe
 import polarion_rest_api_client as polarion_api
 import pytest
+from capellambse import model as m
 
 from capella2polarion import cli, data_models
 from capella2polarion.connectors import polarion_repo, polarion_worker
@@ -83,7 +84,7 @@ class FakeModelObject(mock.MagicMock):
         name: str = "",
         attribute: t.Any | None = None,
     ):
-        super().__init__(spec=capellambse.model.GenericElement)
+        super().__init__(spec=m.ModelElement)
         self.uuid = uuid
         self.name = name
         self.attribute = attribute

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -11,7 +11,7 @@ import capellambse
 import markupsafe
 import polarion_rest_api_client as polarion_api
 import pytest
-from capellambse.model import common
+from capellambse import model as m
 from capellambse_context_diagrams import context, filters
 
 from capella2polarion import data_models
@@ -635,7 +635,7 @@ class TestModelElements:
         obj = FakeModelObject(
             "uuid6",
             name="Fake 6",
-            attribute=common.ElementList(
+            attribute=m.ElementList(
                 base_object.c2pcli.capella_model,
                 [fake, fake1],
                 FakeModelObject,


### PR DESCRIPTION
There's a few more type errors left, which weren't reported before because hook-mypy didn't have a capellambse installation to check against.

Interestingly I'm also getting a bunch of type errors locally that don't show up in CI. Not sure what those are about yet though (might be false-positives), I'll look into that tomorrow.

Tests are red because there's no 0.6-compatible release of context-diagrams yet. Related PR: <https://github.com/DSD-DBS/capellambse-context-diagrams/pull/131>\
Once that is merged and released, we should also explicitly set the minimum required context-diagrams version to that new release.