### PR TITLE
fix: Remove obsolete link serializers

### DIFF
--- a/capella2polarion/converters/converter_config.py
+++ b/capella2polarion/converters/converter_config.py
@@ -37,7 +37,7 @@ class LinkConfig:
     """
 
     capella_attr: str
-    polarion_role: str | None = None
+    polarion_role: str
     include: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
@@ -288,9 +288,9 @@ def _filter_links(
     for link in links:
         cappela_attr = link.capella_attr.split(".")[0]
         if (
-            cappela_attr == DESCRIPTION_REFERENCE_SERIALIZER
+            cappela_attr.endswith(DESCRIPTION_REFERENCE_SERIALIZER)
             or (
-                cappela_attr == DIAGRAM_ELEMENTS_SERIALIZER
+                cappela_attr.endswith(DIAGRAM_ELEMENTS_SERIALIZER)
                 and c_class == diagram.Diagram
             )
             or hasattr(c_class, cappela_attr)

--- a/capella2polarion/converters/converter_config.py
+++ b/capella2polarion/converters/converter_config.py
@@ -286,27 +286,25 @@ def _filter_links(
 
     available_links = []
     for link in links:
-        cappela_attr = link.capella_attr.split(".")[0]
+        capella_attr = link.capella_attr.split(".")[0]
+        is_diagram_elements = capella_attr == DIAGRAM_ELEMENTS_SERIALIZER
         if (
-            cappela_attr.endswith(DESCRIPTION_REFERENCE_SERIALIZER)
-            or (
-                cappela_attr.endswith(DIAGRAM_ELEMENTS_SERIALIZER)
-                and c_class == diagram.Diagram
-            )
-            or hasattr(c_class, cappela_attr)
+            capella_attr == DESCRIPTION_REFERENCE_SERIALIZER
+            or (is_diagram_elements and c_class == diagram.Diagram)
+            or hasattr(c_class, capella_attr)
         ):
             available_links.append(link)
         else:
             if is_global:
                 logger.info(
                     "Global link %s is not available on Capella type %s",
-                    cappela_attr,
+                    capella_attr,
                     c_type,
                 )
             else:
                 logger.error(
                     "Link %s is not available on Capella type %s",
-                    cappela_attr,
+                    capella_attr,
                     c_type,
                 )
     return available_links

--- a/capella2polarion/converters/document_renderer.py
+++ b/capella2polarion/converters/document_renderer.py
@@ -433,7 +433,8 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
                         )
                     except Exception as e:
                         logger.error(
-                            "Rendering for document %s/%s failed with the following error",
+                            "Rendering for document %s/%s failed with the "
+                            "following error",
                             instance.polarion_space,
                             instance.polarion_name,
                             exc_info=e,
@@ -456,7 +457,8 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
                         )
                     except Exception as e:
                         logger.error(
-                            "Rendering for document %s/%s failed with the following error",
+                            "Rendering for document %s/%s failed with the "
+                            "following error",
                             instance.polarion_space,
                             instance.polarion_name,
                             exc_info=e,

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -12,7 +12,6 @@ import capellambse
 import polarion_rest_api_client as polarion_api
 from capellambse.model import common
 from capellambse.model import diagram as diag
-from capellambse.model.crosslayer import fa
 
 import capella2polarion.converters.polarion_html_helper
 from capella2polarion import data_models
@@ -64,7 +63,7 @@ class LinkSerializer:
         for link_config in converter_data.type_config.links:
             assert (role_id := link_config.polarion_role) is not None
             attr_id = link_config.capella_attr or ""
-            serializer = self.serializers.get(role_id)
+            serializer = self.serializers.get(attr_id)
             if self.role_prefix:
                 role_id = f"{self.role_prefix}_{role_id}"
             try:
@@ -228,11 +227,12 @@ class LinkSerializer:
                     config = link_config
                     break
 
+            role_id = role
+            if self.role_prefix:
+                role_id = role.removeprefix(f"{self.role_prefix}_")
+
             self._create_link_fields(
-                work_item,
-                role.removeprefix(f"{self.role_prefix}_"),
-                grouped_links,
-                config=config,
+                work_item, role_id, grouped_links, config=config
             )
 
     def _create_link_fields(
@@ -315,12 +315,11 @@ class LinkSerializer:
             List of links referencing work_item as secondary
         """
         for role, grouped_links in _group_by("role", links).items():
-            self._create_link_fields(
-                work_item,
-                role.removeprefix(f"{self.role_prefix}_"),
-                grouped_links,
-                True,
-            )
+            role_id = role
+            if self.role_prefix:
+                role_id = role.removeprefix(f"{self.role_prefix}_")
+
+            self._create_link_fields(work_item, role_id, grouped_links, True)
 
 
 def _group_by(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,8 @@ import pytest
 from click import testing
 
 import capella2polarion.__main__ as main
-from capella2polarion.connectors.polarion_worker import CapellaPolarionWorker
+from capella2polarion.connectors import polarion_worker
+from capella2polarion.converters import model_converter
 
 # pylint: disable-next=relative-beyond-top-level, useless-suppression
 from .conftest import (  # type: ignore[import]
@@ -26,25 +27,31 @@ def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
     mock_get_polarion_wi_map = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "load_polarion_work_item_map",
         mock_get_polarion_wi_map,
     )
+    mock_generate_work_items = mock.MagicMock()
+    monkeypatch.setattr(
+        model_converter.ModelConverter,
+        "generate_work_items",
+        mock_generate_work_items,
+    )
     mock_delete_work_items = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "delete_orphaned_work_items",
         mock_delete_work_items,
     )
     mock_post_work_items = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "create_missing_work_items",
         mock_post_work_items,
     )
     mock_patch_work_items = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "compare_and_update_work_items",
         mock_patch_work_items,
     )
@@ -68,6 +75,11 @@ def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
 
     assert result.exit_code == 0
     assert mock_get_polarion_wi_map.call_count == 1
+    assert mock_generate_work_items.call_count == 2
+    assert mock_generate_work_items.call_args_list[1][1] == {
+        "generate_links": True,
+        "generate_attachments": True,
+    }
     assert mock_delete_work_items.call_count == 1
     assert mock_patch_work_items.call_count == 1
     assert mock_post_work_items.call_count == 1
@@ -78,7 +90,7 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
     mock_get_polarion_wi_map = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "load_polarion_work_item_map",
         mock_get_polarion_wi_map,
     )
@@ -96,25 +108,25 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         else None
     )
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "get_document",
         mock_get_document,
     )
     mock_post_documents = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "post_documents",
         mock_post_documents,
     )
     mock_update_documents = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "update_documents",
         mock_update_documents,
     )
     mock_update_work_items = mock.MagicMock()
     monkeypatch.setattr(
-        CapellaPolarionWorker,
+        polarion_worker.CapellaPolarionWorker,
         "update_work_items",
         mock_update_work_items,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,7 +101,8 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
             module_name=name,
             home_page_content=polarion_api.TextContent(
                 "text/html",
-                '<h1 id="polarion_wiki macro name=module-workitem;params=id=TEST-123></h1>',
+                '<h1 id="polarion_wiki macro name=module-workitem;'
+                'params=id=TEST-123"></h1>',
             ),
         )
         if name == "id1236"

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -474,7 +474,7 @@ class TestModelElements:
             assert False
 
         link_serializer.serializers["invalid_role"] = (
-            lambda obj, work_item_id, role_id, attr_id, links: error()
+            lambda obj, work_item_id, role_id, links: error()
         )
 
         with caplog.at_level(logging.ERROR):
@@ -550,7 +550,7 @@ class TestModelElements:
             assert False
 
         link_serializer.serializers["invalid_role"] = (
-            lambda obj, work_item_id, role_id, attr_id, links: error()
+            lambda obj, work_item_id, role_id, links: error()
         )
 
         with caplog.at_level(logging.WARNING):

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -162,6 +162,55 @@ HTML_LINK_3 = {
 DIAGRAM_CONFIG = converter_config.CapellaTypeConfig("diagram", "diagram")
 
 
+class GroupedLinksBaseObject(t.TypedDict):
+    link_serializer: link_converter.LinkSerializer
+    work_items: dict[str, data_models.CapellaWorkItem]
+    back_links: dict[str, list[polarion_api.WorkItemLink]]
+    reverse_polarion_id_map: dict[str, str]
+    config: converter_config.CapellaTypeConfig
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture()
+def grouped_links_base_object(
+    base_object: BaseObjectContainer,
+    dummy_work_items: dict[str, data_models.CapellaWorkItem],
+) -> GroupedLinksBaseObject:
+    reverse_polarion_id_map = {v: k for k, v in POLARION_ID_MAP.items()}
+    back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+    config = converter_config.CapellaTypeConfig(
+        "fakeModelObject",
+        links=[
+            converter_config.LinkConfig(
+                capella_attr="attribute", polarion_role="attribute"
+            )
+        ],
+    )
+    mock_model = mock.MagicMock()
+    fake_2 = FakeModelObject("uuid2", "Fake 2")
+    fake_1 = FakeModelObject("uuid1", "Fake 1")
+    fake_0 = FakeModelObject("uuid0", "Fake 0", attribute=[fake_1, fake_2])
+    fake_1.attribute = [fake_0, fake_2]
+    mock_model.by_uuid.side_effect = lambda uuid: {
+        "uuid0": fake_0,
+        "uuid1": fake_1,
+        "uuid2": fake_2,
+    }[uuid]
+    link_serializer = link_converter.LinkSerializer(
+        base_object.pw.polarion_data_repo,
+        base_object.mc.converter_session,
+        base_object.pw.polarion_params.project_id,
+        mock_model,
+    )
+    return {
+        "link_serializer": link_serializer,
+        "work_items": dummy_work_items,
+        "back_links": back_links,
+        "reverse_polarion_id_map": reverse_polarion_id_map,
+        "config": config,
+    }
+
+
 class TestDiagramElements:
     @staticmethod
     @pytest.fixture
@@ -1251,35 +1300,16 @@ class TestModelElements:
 
     @staticmethod
     def test_maintain_reverse_grouped_links_attributes(
-        base_object: BaseObjectContainer,
-        dummy_work_items: dict[str, data_models.CapellaWorkItem],
+        grouped_links_base_object: GroupedLinksBaseObject,
     ):
-        reverse_polarion_id_map = {v: k for k, v in POLARION_ID_MAP.items()}
-        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
-        config = converter_config.CapellaTypeConfig(
-            "fakeModelObject",
-            links=[
-                converter_config.LinkConfig(
-                    capella_attr="attribute", polarion_role="attribute"
-                )
-            ],
-        )
-        mock_model = mock.MagicMock()
-        fake_2 = FakeModelObject("uuid2", "Fake 2")
-        fake_1 = FakeModelObject("uuid1", "Fake 1")
-        fake_0 = FakeModelObject("uuid0", "Fake 0", attribute=[fake_1, fake_2])
-        fake_1.attribute = [fake_0, fake_2]
-        mock_model.by_uuid.side_effect = lambda uuid: {
-            "uuid0": fake_0,
-            "uuid1": fake_1,
-            "uuid2": fake_2,
-        }[uuid]
-        link_serializer = link_converter.LinkSerializer(
-            base_object.pw.polarion_data_repo,
-            base_object.mc.converter_session,
-            base_object.pw.polarion_params.project_id,
-            mock_model,
-        )
+        link_serializer = grouped_links_base_object["link_serializer"]
+        dummy_work_items = grouped_links_base_object["work_items"]
+        reverse_polarion_id_map = grouped_links_base_object[
+            "reverse_polarion_id_map"
+        ]
+        back_links = grouped_links_base_object["back_links"]
+        config = grouped_links_base_object["config"]
+
         for work_item in dummy_work_items.values():
             converter_data = data_session.ConverterData(
                 "test", config, [], work_item
@@ -1287,15 +1317,10 @@ class TestModelElements:
             link_serializer.create_grouped_link_fields(
                 converter_data, back_links
             )
-
         for work_item_id, links in back_links.items():
             work_item = dummy_work_items[reverse_polarion_id_map[work_item_id]]
             link_serializer.create_grouped_back_link_fields(work_item, links)
-        del dummy_work_items["uuid0"].additional_attributes["uuid_capella"]
-        del dummy_work_items["uuid1"].additional_attributes["uuid_capella"]
-        del dummy_work_items["uuid2"].additional_attributes["uuid_capella"]
-        del dummy_work_items["uuid0"].additional_attributes["attribute"]
-        del dummy_work_items["uuid1"].additional_attributes["attribute"]
+
         assert (
             dummy_work_items["uuid0"].additional_attributes.pop(
                 "attribute_reverse"
@@ -1314,44 +1339,22 @@ class TestModelElements:
             )["value"]
             == HTML_LINK_2["attribute_reverse"]
         )
-        assert dummy_work_items["uuid0"].additional_attributes == {}
-        assert dummy_work_items["uuid1"].additional_attributes == {}
-        assert dummy_work_items["uuid2"].additional_attributes == {}
 
     @staticmethod
     def test_maintain_reverse_grouped_links_attributes_with_role_prefix(
-        base_object: BaseObjectContainer,
-        dummy_work_items: dict[str, data_models.CapellaWorkItem],
+        grouped_links_base_object: GroupedLinksBaseObject,
     ):
-        reverse_polarion_id_map = {v: k for k, v in POLARION_ID_MAP.items()}
-        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
-        config = converter_config.CapellaTypeConfig(
-            "fakeModelObject",
-            links=[
-                converter_config.LinkConfig(
-                    capella_attr="attribute", polarion_role="attribute"
-                )
-            ],
-        )
-        mock_model = mock.MagicMock()
-        fake_2 = FakeModelObject("uuid2", "Fake 2")
-        fake_1 = FakeModelObject("uuid1", "Fake 1")
-        fake_0 = FakeModelObject("uuid0", "Fake 0", attribute=[fake_1, fake_2])
-        fake_1.attribute = [fake_0, fake_2]
-        mock_model.by_uuid.side_effect = lambda uuid: {
-            "uuid0": fake_0,
-            "uuid1": fake_1,
-            "uuid2": fake_2,
-        }[uuid]
+        link_serializer = grouped_links_base_object["link_serializer"]
+        dummy_work_items = grouped_links_base_object["work_items"]
+        reverse_polarion_id_map = grouped_links_base_object[
+            "reverse_polarion_id_map"
+        ]
+        back_links = grouped_links_base_object["back_links"]
+        config = grouped_links_base_object["config"]
         for link in dummy_work_items["uuid0"].linked_work_items:
             link.role = f"_C2P_{link.role}"
-        link_serializer = link_converter.LinkSerializer(
-            base_object.pw.polarion_data_repo,
-            base_object.mc.converter_session,
-            base_object.pw.polarion_params.project_id,
-            mock_model,
-            role_prefix="_C2P",
-        )
+        link_serializer.role_prefix = "_C2P"
+
         for work_item in dummy_work_items.values():
             converter_data = data_session.ConverterData(
                 "test", config, [], work_item
@@ -1359,7 +1362,6 @@ class TestModelElements:
             link_serializer.create_grouped_link_fields(
                 converter_data, back_links
             )
-
         for work_item_id, links in back_links.items():
             work_item = dummy_work_items[reverse_polarion_id_map[work_item_id]]
             link_serializer.create_grouped_back_link_fields(work_item, links)


### PR DESCRIPTION
- Removed obsolete `handle_exchanges` custom link serializers and therefore remove one parameter passed to the serializers
- Mocked the generation of work items in the CLI test as this unnecessarily tests what is already covered in the unit tests