### PR TITLE
refactor: Refactor prefixes

### DIFF
--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 @click.option("--polarion-pat", envvar="POLARION_PAT", type=str)
 @click.option("--polarion-delete-work-items", is_flag=True, default=False)
 @click.option("--capella-model", type=cli_helpers.ModelCLI(), default=None)
+@click.option("--force-update", is_flag=True, default=False)
 @click.option("--type-prefix", type=str, default="")
 @click.option("--role-prefix", type=str, default="")
 @click.pass_context
@@ -49,6 +50,7 @@ def cli(
     polarion_pat: str,
     polarion_delete_work_items: bool,
     capella_model: capellambse.MelodyModel,
+    force_update: bool,
     type_prefix: str,
     role_prefix: str,
 ) -> None:
@@ -63,8 +65,9 @@ def cli(
         polarion_pat,
         polarion_delete_work_items,
         capella_model,
-        type_prefix=type_prefix,
-        role_prefix=role_prefix,
+        force_update,
+        type_prefix,
+        role_prefix,
     )
     capella2polarion_cli.setup_logger()
     ctx.obj = capella2polarion_cli
@@ -84,11 +87,9 @@ def print_cli_state(capella2polarion_cli: Capella2PolarionCli) -> None:
     type=click.File(mode="r", encoding="utf8"),
     default=None,
 )
-@click.option("--force-update", is_flag=True, default=False)
 @click.pass_context
 def synchronize(
     ctx: click.core.Context,
-    force_update: bool,
     synchronize_config: typing.TextIO,
 ) -> None:
     """Synchronise model elements."""
@@ -98,7 +99,6 @@ def synchronize(
         capella_to_polarion_cli.polarion_params.project_id,
     )
     capella_to_polarion_cli.load_synchronize_config(synchronize_config)
-    capella_to_polarion_cli.force_update = force_update
 
     converter = model_converter.ModelConverter(
         capella_to_polarion_cli.capella_model,

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 @click.option("--polarion-pat", envvar="POLARION_PAT", type=str)
 @click.option("--polarion-delete-work-items", is_flag=True, default=False)
 @click.option("--capella-model", type=cli_helpers.ModelCLI(), default=None)
+@click.option("--type-prefix", type=str, default="")
+@click.option("--role-prefix", type=str, default="")
 @click.pass_context
 def cli(
     ctx: click.core.Context,
@@ -47,6 +49,8 @@ def cli(
     polarion_pat: str,
     polarion_delete_work_items: bool,
     capella_model: capellambse.MelodyModel,
+    type_prefix: str,
+    role_prefix: str,
 ) -> None:
     """Synchronise data from Capella to Polarion."""
     if capella_model.diagram_cache is None:
@@ -59,6 +63,8 @@ def cli(
         polarion_pat,
         polarion_delete_work_items,
         capella_model,
+        type_prefix=type_prefix,
+        role_prefix=role_prefix,
     )
     capella2polarion_cli.setup_logger()
     ctx.obj = capella2polarion_cli
@@ -79,15 +85,11 @@ def print_cli_state(capella2polarion_cli: Capella2PolarionCli) -> None:
     default=None,
 )
 @click.option("--force-update", is_flag=True, default=False)
-@click.option("--type-prefix", type=str, default="")
-@click.option("--role-prefix", type=str, default="")
 @click.pass_context
 def synchronize(
     ctx: click.core.Context,
     force_update: bool,
     synchronize_config: typing.TextIO,
-    type_prefix: str,
-    role_prefix: str,
 ) -> None:
     """Synchronise model elements."""
     capella_to_polarion_cli: Capella2PolarionCli = ctx.obj
@@ -97,13 +99,10 @@ def synchronize(
     )
     capella_to_polarion_cli.load_synchronize_config(synchronize_config)
     capella_to_polarion_cli.force_update = force_update
-    capella_to_polarion_cli.type_prefix = type_prefix
-    capella_to_polarion_cli.role_prefix = role_prefix
 
     converter = model_converter.ModelConverter(
         capella_to_polarion_cli.capella_model,
         capella_to_polarion_cli.polarion_params.project_id,
-        type_prefix=capella_to_polarion_cli.type_prefix,
         role_prefix=capella_to_polarion_cli.role_prefix,
     )
 

--- a/capella2polarion/cli.py
+++ b/capella2polarion/cli.py
@@ -28,8 +28,6 @@ class Capella2PolarionCli:
         polarion_delete_work_items: bool,
         capella_model: capellambse.MelodyModel,
         force_update: bool = False,
-        type_prefix: str = "",
-        role_prefix: str = "",
     ) -> None:
         self.debug = debug
         self.polarion_params = pw.PolarionWorkerParams(
@@ -42,8 +40,6 @@ class Capella2PolarionCli:
         self.capella_model = capella_model
         self.config = converter_config.ConverterConfig()
         self.force_update = force_update
-        self.type_prefix = type_prefix
-        self.role_prefix = role_prefix
 
     def _none_save_value_string(self, value: str | None) -> str | None:
         return "None" if value is None else value
@@ -97,7 +93,10 @@ class Capella2PolarionCli:
         logging.getLogger("httpcore").setLevel("WARNING")
 
     def load_synchronize_config(
-        self, synchronize_config_io: typing.TextIO
+        self,
+        synchronize_config_io: typing.TextIO,
+        type_prefix: str = "",
+        role_prefix: str = "",
     ) -> None:
         """Read the sync config into SynchronizeConfigContent.
 
@@ -107,4 +106,6 @@ class Capella2PolarionCli:
             raise RuntimeError("synchronize config io stream is closed ")
         if not synchronize_config_io.readable():
             raise RuntimeError("synchronize config io stream is not readable")
-        self.config.read_config_file(synchronize_config_io)
+        self.config.read_config_file(
+            synchronize_config_io, type_prefix, role_prefix
+        )

--- a/capella2polarion/converters/converter_config.py
+++ b/capella2polarion/converters/converter_config.py
@@ -191,17 +191,16 @@ class ConverterConfig:
             if isinstance(link, str):
                 config = LinkConfig(
                     capella_attr=link,
-                    polarion_role=(pid := add_prefix(link, self._role_prefix)),
-                    link_field=pid,
-                    reverse_field=f"{pid}_reverse",
+                    polarion_role=add_prefix(link, self._role_prefix),
+                    link_field=link,
+                    reverse_field=f"{link}_reverse",
                 )
             elif isinstance(link, dict):
                 config = LinkConfig(
                     capella_attr=(lid := link["capella_attr"]),
-                    polarion_role=(
-                        pid := add_prefix(
-                            link.get("polarion_role", lid), self._role_prefix
-                        )
+                    polarion_role=add_prefix(
+                        (pid := link.get("polarion_role", lid)), 
+                        self._role_prefix
                     ),
                     include=link.get("include", {}),
                     link_field=(lf := link.get("link_field", pid)),

--- a/capella2polarion/converters/converter_config.py
+++ b/capella2polarion/converters/converter_config.py
@@ -199,8 +199,8 @@ class ConverterConfig:
                 config = LinkConfig(
                     capella_attr=(lid := link["capella_attr"]),
                     polarion_role=add_prefix(
-                        (pid := link.get("polarion_role", lid)), 
-                        self._role_prefix
+                        (pid := link.get("polarion_role", lid)),
+                        self._role_prefix,
                     ),
                     include=link.get("include", {}),
                     link_field=(lf := link.get("link_field", pid)),

--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -85,13 +85,11 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
         capella_polarion_mapping: polarion_repo.PolarionDataRepository,
         converter_session: data_session.ConverterSession,
         generate_attachments: bool,
-        type_prefix: str = "",
     ):
         self.model = model
         self.capella_polarion_mapping = capella_polarion_mapping
         self.converter_session = converter_session
         self.generate_attachments = generate_attachments
-        self.type_prefix = type_prefix
         self.jinja_envs: dict[str, jinja2.Environment] = {}
 
     def serialize_all(self) -> list[data_models.CapellaWorkItem]:
@@ -124,11 +122,6 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
                     ", ".join([str(a) for a in error.args])
                 )
                 converter_data.work_item = None
-
-        if self.type_prefix and converter_data.work_item is not None:
-            converter_data.work_item.type = (
-                f"{self.type_prefix}_{converter_data.work_item.type}"
-            )
 
         if converter_data.errors:
             log_args = (

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -63,8 +63,6 @@ class LinkSerializer:
         for link_config in converter_data.type_config.links:
             serializer = self.serializers.get(link_config.capella_attr)
             role_id = link_config.polarion_role
-            if self.role_prefix:
-                role_id = f"{self.role_prefix}_{role_id}"
             try:
                 if serializer:
                     new_links.extend(
@@ -225,13 +223,13 @@ class LinkSerializer:
                     key = link.secondary_work_item_id
                     back_links.setdefault(key, []).append(link)
 
-            role_id = self._remove_prefix(role)
             config: converter_config.LinkConfig | None = None
             for link_config in data.type_config.links:
-                if link_config.polarion_role == role_id:
+                if link_config.polarion_role == role:
                     config = link_config
                     break
 
+            role_id = self._remove_prefix(role)
             self._create_link_fields(
                 work_item, role_id, grouped_links, config=config
             )

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -36,13 +36,11 @@ class LinkSerializer:
         converter_session: data_session.ConverterSession,
         project_id: str,
         model: capellambse.MelodyModel,
-        role_prefix: str = "",
     ):
         self.capella_polarion_mapping = capella_polarion_mapping
         self.converter_session = converter_session
         self.project_id = project_id
         self.model = model
-        self.role_prefix = role_prefix
 
         self.serializers: dict[str, _Serializer] = {
             converter_config.DESCRIPTION_REFERENCE_SERIALIZER: self._handle_description_reference_links,  # pylint: disable=line-too-long
@@ -223,16 +221,11 @@ class LinkSerializer:
                     key = link.secondary_work_item_id
                     back_links.setdefault(key, []).append(link)
 
-            config: converter_config.LinkConfig | None = None
-            for link_config in data.type_config.links:
-                if link_config.polarion_role == role:
-                    config = link_config
-                    break
-
-            role_id = self._remove_prefix(role)
-            self._create_link_fields(
-                work_item, role_id, grouped_links, config=config
-            )
+            config = find_link_config(data, role)
+            if config is not None and config.link_field:
+                self._create_link_fields(
+                    work_item, config.link_field, grouped_links, config=config
+                )
 
     def _create_link_fields(
         self,
@@ -244,7 +237,6 @@ class LinkSerializer:
     ):
         link_map: dict[str, dict[str, list[str]]]
         if reverse:
-            role = f"{role}_reverse"
             link_map = {link.primary_work_item_id: {} for link in links}
         else:
             link_map = {link.secondary_work_item_id: {} for link in links}
@@ -301,26 +293,41 @@ class LinkSerializer:
 
     def create_grouped_back_link_fields(
         self,
-        work_item: data_models.CapellaWorkItem,
+        data: data_session.ConverterData,
         links: list[polarion_api.WorkItemLink],
     ):
         """Create fields for the given WorkItem using a list of backlinks.
 
         Parameters
         ----------
-        work_item
-            WorkItem to create the fields for
+        data
+            The ConverterData that stores the WorkItem to create the
+            fields for.
         links
-            List of links referencing work_item as secondary
+            List of links referencing work_item as secondary.
         """
+        work_item = data.work_item
+        assert work_item is not None
+        wi = f"[{work_item.id}]({work_item.type} {work_item.title})"
+        logger.debug("Building grouped back links for work item %r...", wi)
         for role, grouped_links in _group_by("role", links).items():
-            role_id = self._remove_prefix(role)
-            self._create_link_fields(work_item, role_id, grouped_links, True)
+            config = find_link_config(data, role)
+            if config is not None and config.reverse_field:
+                self._create_link_fields(
+                    work_item, config.reverse_field, grouped_links, True
+                )
 
-    def _remove_prefix(self, role: str) -> str:
-        if self.role_prefix:
-            return role.removeprefix(f"{self.role_prefix}_")
-        return role
+
+def find_link_config(
+    data: data_session.ConverterData, role: str
+) -> converter_config.LinkConfig | None:
+    """Search for LinkConfig with matching polarion_role in ``data``."""
+    for link_config in data.type_config.links:
+        if link_config.polarion_role == role:
+            return link_config
+
+    logger.error("No LinkConfig found for %r", role)
+    return None
 
 
 def _group_by(

--- a/capella2polarion/converters/model_converter.py
+++ b/capella2polarion/converters/model_converter.py
@@ -29,11 +29,9 @@ class ModelConverter:
         self,
         model: capellambse.MelodyModel,
         project_id: str,
-        role_prefix: str = "",
     ):
         self.model = model
         self.project_id = project_id
-        self.role_prefix = role_prefix
 
         self.converter_session: data_session.ConverterSession = {}
 
@@ -130,7 +128,6 @@ class ModelConverter:
             self.converter_session,
             self.project_id,
             self.model,
-            self.role_prefix,
         )
         for uuid, converter_data in self.converter_session.items():
             if converter_data.work_item is None:
@@ -155,7 +152,8 @@ class ModelConverter:
                 )
                 continue
 
+            assert converter_data.work_item.id is not None
             if local_back_links := back_links.get(converter_data.work_item.id):
                 link_serializer.create_grouped_back_link_fields(
-                    converter_data.work_item, local_back_links
+                    converter_data, local_back_links
                 )

--- a/capella2polarion/converters/model_converter.py
+++ b/capella2polarion/converters/model_converter.py
@@ -29,12 +29,10 @@ class ModelConverter:
         self,
         model: capellambse.MelodyModel,
         project_id: str,
-        type_prefix: str = "",
         role_prefix: str = "",
     ):
         self.model = model
         self.project_id = project_id
-        self.type_prefix = type_prefix
         self.role_prefix = role_prefix
 
         self.converter_session: data_session.ConverterSession = {}
@@ -110,7 +108,6 @@ class ModelConverter:
             polarion_data_repo,
             self.converter_session,
             generate_attachments,
-            self.type_prefix,
         )
         work_items = serializer.serialize_all()
         for work_item in work_items:

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -17,8 +17,8 @@ capella2polarion_synchronise_elements:
         $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
         --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
         --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
+        ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
+        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"} \
         synchronize \
         --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
-        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
-        ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
-        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"}
+        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update')

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -17,8 +17,8 @@ capella2polarion_synchronise_elements:
         $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
         --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
         --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
+        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
         ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
         ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"} \
         synchronize \
-        --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
-        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update')
+        --synchronize-config=${CAPELLA2POLARION_CONFIG:?}

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -17,8 +17,8 @@ capella2polarion_synchronise_elements:
         $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
         --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
         --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
+        synchronize \
+        --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
         $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
         ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
-        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"} \
-        synchronize \
-        --synchronize-config=${CAPELLA2POLARION_CONFIG:?}
+        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"}

--- a/tests/data/model_elements/config.yaml
+++ b/tests/data/model_elements/config.yaml
@@ -55,10 +55,14 @@ sa:
         capella_attr: inputs.exchanges
         include:
           Exchange Items: exchange_items
+        link_field: inputExchanges
+        reverse_field: inputExchangesReverse
       - polarion_role: output_exchanges
         capella_attr: outputs.exchanges
         include:
           Exchange Items: exchange_items
+        link_field: output_exchanges
+        reverse_field: output_exchanges_reverse
   FunctionalExchange:
     links:
       - exchanged_items

--- a/tests/data/model_elements/config.yaml
+++ b/tests/data/model_elements/config.yaml
@@ -61,8 +61,6 @@ sa:
         capella_attr: outputs.exchanges
         include:
           Exchange Items: exchange_items
-        link_field: output_exchanges
-        reverse_field: output_exchanges_reverse
   FunctionalExchange:
     links:
       - exchanged_items

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1225,11 +1225,8 @@ class TestModelElements:
         )
 
     @staticmethod
-    @pytest.mark.parametrize("role_prefix", ["", "_C2P"])
     def test_grouped_links_attributes_with_includes(
-        base_object: BaseObjectContainer,
-        model: capellambse.MelodyModel,
-        role_prefix: str,
+        base_object: BaseObjectContainer, model: capellambse.MelodyModel
     ):
         fnc = model.by_uuid(TEST_SYS_FNC)
         ex = model.by_uuid(TEST_SYS_FNC_EX)
@@ -1273,7 +1270,6 @@ class TestModelElements:
         converter = model_converter.ModelConverter(
             base_object.c2pcli.capella_model,
             base_object.c2pcli.polarion_params.project_id,
-            role_prefix=role_prefix,
         )
         converter.converter_session = base_object.mc.converter_session
         work_items = converter.generate_work_items(
@@ -1291,7 +1287,6 @@ class TestModelElements:
             base_object.mc.converter_session,
             base_object.pw.polarion_params.project_id,
             base_object.c2pcli.capella_model,
-            role_prefix=role_prefix,
         )
         backlinks: dict[str, list[polarion_api.WorkItemLink]] = {}
         work_item = (

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -165,8 +165,6 @@ DIAGRAM_CONFIG = converter_config.CapellaTypeConfig("diagram", "diagram")
 class GroupedLinksBaseObject(t.TypedDict):
     link_serializer: link_converter.LinkSerializer
     work_items: dict[str, data_models.CapellaWorkItem]
-    back_links: dict[str, list[polarion_api.WorkItemLink]]
-    reverse_polarion_id_map: dict[str, str]
     config: converter_config.CapellaTypeConfig
 
 
@@ -176,13 +174,14 @@ def grouped_links_base_object(
     base_object: BaseObjectContainer,
     dummy_work_items: dict[str, data_models.CapellaWorkItem],
 ) -> GroupedLinksBaseObject:
-    reverse_polarion_id_map = {v: k for k, v in POLARION_ID_MAP.items()}
-    back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
     config = converter_config.CapellaTypeConfig(
         "fakeModelObject",
         links=[
             converter_config.LinkConfig(
-                capella_attr="attribute", polarion_role="attribute"
+                capella_attr="attribute",
+                polarion_role="attribute",
+                link_field="attribute",
+                reverse_field="attribute_reverse",
             )
         ],
     )
@@ -205,8 +204,6 @@ def grouped_links_base_object(
     return {
         "link_serializer": link_serializer,
         "work_items": dummy_work_items,
-        "back_links": back_links,
-        "reverse_polarion_id_map": reverse_polarion_id_map,
         "config": config,
     }
 
@@ -733,7 +730,6 @@ class TestModelElements:
             base_object.mc.converter_session,
             base_object.pw.polarion_params.project_id,
             base_object.c2pcli.capella_model,
-            role_prefix="_C2P",
         )
 
         links = link_serializer.create_links_for_work_item("uuid2")
@@ -1135,7 +1131,10 @@ class TestModelElements:
             "fakeModelObject",
             links=[
                 converter_config.LinkConfig(
-                    capella_attr="attribute", polarion_role="attribute"
+                    capella_attr="attribute",
+                    polarion_role="attribute",
+                    link_field="attribute",
+                    reverse_field="attribute_reverse",
                 )
             ],
         )
@@ -1188,7 +1187,10 @@ class TestModelElements:
             "fakeModelObject",
             links=[
                 converter_config.LinkConfig(
-                    capella_attr="attribute", polarion_role="attribute"
+                    capella_attr="attribute",
+                    polarion_role="_C2P_attribute",
+                    link_field="attribute",
+                    reverse_field="attribute_reverse",
                 )
             ],
         )
@@ -1209,7 +1211,6 @@ class TestModelElements:
             base_object.mc.converter_session,
             base_object.pw.polarion_params.project_id,
             mock_model,
-            role_prefix="_C2P",
         )
 
         for work_item in dummy_work_items.values():
@@ -1219,7 +1220,9 @@ class TestModelElements:
             link_serializer.create_grouped_link_fields(converter_data)
 
         assert "attribute" in dummy_work_items["uuid0"].additional_attributes
-        assert "attribute" in dummy_work_items["uuid1"].additional_attributes
+        assert (  # Link Role on links were not prefixed
+            "attribute" not in dummy_work_items["uuid1"].additional_attributes
+        )
 
     @staticmethod
     @pytest.mark.parametrize("role_prefix", ["", "_C2P"])
@@ -1234,16 +1237,23 @@ class TestModelElements:
             "systemFunction",
             links=[
                 converter_config.LinkConfig(
-                    "inputs.exchanges",
-                    "input_exchanges",
+                    capella_attr="inputs.exchanges",
+                    polarion_role="input_exchanges",
                     include={"Exchange Items": "exchange_items"},
+                    link_field="input_exchanges",
+                    reverse_field="input_exchanges_reverse",
                 )
             ],
         )
         ex_config = converter_config.CapellaTypeConfig(
             "systemFunctionalExchange",
             links=[
-                converter_config.LinkConfig("exchange_items", "exchange_items")
+                converter_config.LinkConfig(
+                    capella_attr="exchange_items",
+                    polarion_role="exchange_items",
+                    link_field="exchange_items",
+                    reverse_field="exchange_items_reverse",
+                )
             ],
         )
         ex_item_config = converter_config.CapellaTypeConfig("exchangeItem")
@@ -1312,22 +1322,21 @@ class TestModelElements:
     ):
         link_serializer = grouped_links_base_object["link_serializer"]
         dummy_work_items = grouped_links_base_object["work_items"]
-        reverse_polarion_id_map = grouped_links_base_object[
-            "reverse_polarion_id_map"
-        ]
-        back_links = grouped_links_base_object["back_links"]
         config = grouped_links_base_object["config"]
+        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+        data = {}
 
         for work_item in dummy_work_items.values():
-            converter_data = data_session.ConverterData(
+            data[work_item.id] = converter_data = data_session.ConverterData(
                 "test", config, [], work_item
             )
             link_serializer.create_grouped_link_fields(
                 converter_data, back_links
             )
         for work_item_id, links in back_links.items():
-            work_item = dummy_work_items[reverse_polarion_id_map[work_item_id]]
-            link_serializer.create_grouped_back_link_fields(work_item, links)
+            link_serializer.create_grouped_back_link_fields(
+                data[work_item_id], links
+            )
 
         assert (
             dummy_work_items["uuid0"].additional_attributes.pop(
@@ -1354,25 +1363,27 @@ class TestModelElements:
     ):
         link_serializer = grouped_links_base_object["link_serializer"]
         dummy_work_items = grouped_links_base_object["work_items"]
-        reverse_polarion_id_map = grouped_links_base_object[
-            "reverse_polarion_id_map"
-        ]
-        back_links = grouped_links_base_object["back_links"]
         config = grouped_links_base_object["config"]
-        for link in dummy_work_items["uuid0"].linked_work_items:
+        config.links[0].polarion_role = f"_C2P_{config.links[0].polarion_role}"
+        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+        data = {}
+        for link in (
+            dummy_work_items["uuid0"].linked_work_items
+            + dummy_work_items["uuid1"].linked_work_items
+        ):
             link.role = f"_C2P_{link.role}"
-        link_serializer.role_prefix = "_C2P"
 
         for work_item in dummy_work_items.values():
-            converter_data = data_session.ConverterData(
+            data[work_item.id] = converter_data = data_session.ConverterData(
                 "test", config, [], work_item
             )
             link_serializer.create_grouped_link_fields(
                 converter_data, back_links
             )
         for work_item_id, links in back_links.items():
-            work_item = dummy_work_items[reverse_polarion_id_map[work_item_id]]
-            link_serializer.create_grouped_back_link_fields(work_item, links)
+            link_serializer.create_grouped_back_link_fields(
+                data[work_item_id], links
+            )
 
         assert (
             "attribute_reverse"
@@ -1393,12 +1404,24 @@ def test_grouped_linked_work_items_order_consistency(
         base_object.pw.polarion_params.project_id,
         base_object.c2pcli.capella_model,
     )
+    config = converter_config.CapellaTypeConfig(
+        "fakeModelObject",
+        links=[
+            converter_config.LinkConfig(
+                capella_attr="attribute",
+                polarion_role="role1",
+                link_field="attribute1",
+                reverse_field="attribute_reverse",
+            )
+        ],
+    )
     work_item = data_models.CapellaWorkItem("id", "Dummy")
+    converter_data = data_session.ConverterData("test", config, [], work_item)
     links = [
         polarion_api.WorkItemLink("prim1", "id", "role1"),
         polarion_api.WorkItemLink("prim2", "id", "role1"),
     ]
-    link_serializer.create_grouped_back_link_fields(work_item, links)
+    link_serializer.create_grouped_back_link_fields(converter_data, links)
 
     check_sum = work_item.calculate_checksum()
 
@@ -1406,7 +1429,7 @@ def test_grouped_linked_work_items_order_consistency(
         polarion_api.WorkItemLink("prim2", "id", "role1"),
         polarion_api.WorkItemLink("prim1", "id", "role1"),
     ]
-    link_serializer.create_grouped_back_link_fields(work_item, links)
+    link_serializer.create_grouped_back_link_fields(converter_data, links)
 
     assert check_sum == work_item.calculate_checksum()
 
@@ -1889,3 +1912,20 @@ class TestSerializers:
             if link.capella_attr == "parent"
         )
         assert caplog.record_tuples[0] + caplog.record_tuples[1] == expected
+        assert (
+            system_fnc_config := config.get_type_config("sa", "SystemFunction")
+        )
+        assert system_fnc_config.links[0] == converter_config.LinkConfig(
+            capella_attr="inputs.exchanges",
+            polarion_role="input_exchanges",
+            include={"Exchange Items": "exchange_items"},
+            link_field="inputExchanges",
+            reverse_field="inputExchangesReverse",
+        )
+        assert system_fnc_config.links[1] == converter_config.LinkConfig(
+            capella_attr="outputs.exchanges",
+            polarion_role="output_exchanges",
+            include={"Exchange Items": "exchange_items"},
+            link_field="output_exchanges",
+            reverse_field="output_exchanges_reverse",
+        )


### PR DESCRIPTION
This PR changes the handling of prefixes (type_prefix and role_prefix) such that these are added during loading of the configuration instead of adding them during the serialization of `WorkItem`s or `WorkItemLink`s. 