### PR TITLE
Fix backlinks

### DIFF
--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -196,7 +196,9 @@ class LinkSerializer:
     def create_grouped_link_fields(
         self,
         data: data_session.ConverterData,
-        back_links: dict[str, list[polarion_api.WorkItemLink]] | None = None,
+        back_links: (
+            dict[str, dict[str, list[polarion_api.WorkItemLink]]] | None
+        ) = None,
     ):
         """Create the grouped link fields from the primary work item.
 
@@ -216,16 +218,20 @@ class LinkSerializer:
         for role, grouped_links in _group_by(
             "role", work_item.linked_work_items
         ).items():
-            if back_links is not None:
-                for link in grouped_links:
-                    key = link.secondary_work_item_id
-                    back_links.setdefault(key, []).append(link)
+            if (config := find_link_config(data, role)) is not None:
+                if back_links is not None and config.reverse_field:
+                    for link in grouped_links:
+                        back_links.setdefault(
+                            link.secondary_work_item_id, {}
+                        ).setdefault(config.reverse_field, []).append(link)
 
-            config = find_link_config(data, role)
-            if config is not None and config.link_field:
-                self._create_link_fields(
-                    work_item, config.link_field, grouped_links, config=config
-                )
+                if config.link_field:
+                    self._create_link_fields(
+                        work_item,
+                        config.link_field,
+                        grouped_links,
+                        config=config,
+                    )
 
     def _create_link_fields(
         self,
@@ -294,7 +300,7 @@ class LinkSerializer:
     def create_grouped_back_link_fields(
         self,
         data: data_session.ConverterData,
-        links: list[polarion_api.WorkItemLink],
+        links: dict[str, list[polarion_api.WorkItemLink]],
     ):
         """Create fields for the given WorkItem using a list of backlinks.
 
@@ -310,12 +316,10 @@ class LinkSerializer:
         assert work_item is not None
         wi = f"[{work_item.id}]({work_item.type} {work_item.title})"
         logger.debug("Building grouped back links for work item %r...", wi)
-        for role, grouped_links in _group_by("role", links).items():
-            config = find_link_config(data, role)
-            if config is not None and config.reverse_field:
-                self._create_link_fields(
-                    work_item, config.reverse_field, grouped_links, True
-                )
+        for reverse_field, grouped_links in links.items():
+            self._create_link_fields(
+                work_item, reverse_field, grouped_links, True
+            )
 
 
 def find_link_config(

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -299,21 +299,19 @@ class LinkSerializer:
 
     def create_grouped_back_link_fields(
         self,
-        data: data_session.ConverterData,
+        work_item: data_models.CapellaWorkItem,
         links: dict[str, list[polarion_api.WorkItemLink]],
     ):
         """Create fields for the given WorkItem using a list of backlinks.
 
         Parameters
         ----------
-        data
+        work_item
             The ConverterData that stores the WorkItem to create the
             fields for.
         links
-            List of links referencing work_item as secondary.
+            Dict of field names and links referencing work_item as secondary.
         """
-        work_item = data.work_item
-        assert work_item is not None
         wi = f"[{work_item.id}]({work_item.type} {work_item.title})"
         logger.debug("Building grouped back links for work item %r...", wi)
         for reverse_field, grouped_links in links.items():

--- a/capella2polarion/converters/model_converter.py
+++ b/capella2polarion/converters/model_converter.py
@@ -122,7 +122,7 @@ class ModelConverter:
         polarion_data_repo: polarion_repo.PolarionDataRepository,
     ):
         """Generate links for all work items and add custom fields for them."""
-        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+        back_links: dict[str, dict[str, list[polarion_api.WorkItemLink]]] = {}
         link_serializer = link_converter.LinkSerializer(
             polarion_data_repo,
             self.converter_session,

--- a/capella2polarion/converters/model_converter.py
+++ b/capella2polarion/converters/model_converter.py
@@ -155,5 +155,5 @@ class ModelConverter:
             assert converter_data.work_item.id is not None
             if local_back_links := back_links.get(converter_data.work_item.id):
                 link_serializer.create_grouped_back_link_fields(
-                    converter_data, local_back_links
+                    converter_data.work_item, local_back_links
                 )

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1288,7 +1288,7 @@ class TestModelElements:
             base_object.pw.polarion_params.project_id,
             base_object.c2pcli.capella_model,
         )
-        backlinks: dict[str, list[polarion_api.WorkItemLink]] = {}
+        backlinks: dict[str, dict[str, list[polarion_api.WorkItemLink]]] = {}
         work_item = (
             base_object.pw.polarion_data_repo.get_work_item_by_capella_uuid(
                 fnc.uuid
@@ -1318,7 +1318,7 @@ class TestModelElements:
         link_serializer = grouped_links_base_object["link_serializer"]
         dummy_work_items = grouped_links_base_object["work_items"]
         config = grouped_links_base_object["config"]
-        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+        back_links: dict[str, dict[str, list[polarion_api.WorkItemLink]]] = {}
         data = {}
 
         for work_item in dummy_work_items.values():
@@ -1360,7 +1360,7 @@ class TestModelElements:
         dummy_work_items = grouped_links_base_object["work_items"]
         config = grouped_links_base_object["config"]
         config.links[0].polarion_role = f"_C2P_{config.links[0].polarion_role}"
-        back_links: dict[str, list[polarion_api.WorkItemLink]] = {}
+        back_links: dict[str, dict[str, list[polarion_api.WorkItemLink]]] = {}
         data = {}
         for link in (
             dummy_work_items["uuid0"].linked_work_items
@@ -1401,29 +1401,25 @@ def test_grouped_linked_work_items_order_consistency(
     )
     config = converter_config.CapellaTypeConfig(
         "fakeModelObject",
-        links=[
-            converter_config.LinkConfig(
-                capella_attr="attribute",
-                polarion_role="role1",
-                link_field="attribute1",
-                reverse_field="attribute_reverse",
-            )
-        ],
     )
     work_item = data_models.CapellaWorkItem("id", "Dummy")
     converter_data = data_session.ConverterData("test", config, [], work_item)
-    links = [
-        polarion_api.WorkItemLink("prim1", "id", "role1"),
-        polarion_api.WorkItemLink("prim2", "id", "role1"),
-    ]
+    links = {
+        "attribute_reverse": [
+            polarion_api.WorkItemLink("prim1", "id", "role1"),
+            polarion_api.WorkItemLink("prim2", "id", "role1"),
+        ]
+    }
     link_serializer.create_grouped_back_link_fields(converter_data, links)
 
     check_sum = work_item.calculate_checksum()
 
-    links = [
-        polarion_api.WorkItemLink("prim2", "id", "role1"),
-        polarion_api.WorkItemLink("prim1", "id", "role1"),
-    ]
+    links = {
+        "attribute_reverse": [
+            polarion_api.WorkItemLink("prim2", "id", "role1"),
+            polarion_api.WorkItemLink("prim1", "id", "role1"),
+        ]
+    }
     link_serializer.create_grouped_back_link_fields(converter_data, links)
 
     assert check_sum == work_item.calculate_checksum()


### PR DESCRIPTION
Backlinks weren't created properly, because we searched for the link config in the work item we wanted to create the back link in. E.g. we searched in a class which was part of a diagram for the config `diagram_elements` to create the back-link