### PR TITLE
fix: Handle `None` return during link creation

### DIFF
--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -72,11 +72,7 @@ class LinkSerializer:
                     if isinstance(refs, common.ElementList):
                         new = refs.by_uuid  # type: ignore[assignment]
                     elif refs is None:
-                        warning = make_link_logging_message(
-                            "No model element behind that attribute",
-                            link_config.capella_attr,
-                        )
-                        link_errors.extend(warning)
+                        logger.info("For model element %r attribute %s is not set", obj._short_repr_(), link_config.capella_attr)
                         continue
                     else:
                         assert hasattr(refs, "uuid"), "No 'uuid' on value"
@@ -387,7 +383,7 @@ def _resolve_attribute(
 ) -> common.ElementList[common.GenericElement] | common.GenericElement | None:
     attr_name, _, map_id = attr_id.partition(".")
     objs = getattr(obj, attr_name)
-    if map_id:
+    if map_id and objs is not None:
         if isinstance(objs, common.GenericElement):
             return _resolve_attribute(objs, map_id)
         objs = objs.map(map_id)

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -72,7 +72,11 @@ class LinkSerializer:
                     if isinstance(refs, common.ElementList):
                         new = refs.by_uuid  # type: ignore[assignment]
                     elif refs is None:
-                        logger.info("For model element %r attribute %s is not set", obj._short_repr_(), link_config.capella_attr)
+                        logger.info(
+                            'For model element %r attribute "%s" is not set',
+                            obj._short_repr_(),
+                            link_config.capella_attr,
+                        )
                         continue
                     else:
                         assert hasattr(refs, "uuid"), "No 'uuid' on value"

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -491,13 +491,11 @@ class TestModelElements:
         base_object: BaseObjectContainer, caplog: pytest.LogCaptureFixture
     ):
         expected = (
-            "Link creation for \"<FakeModelObject 'Fake 1' (uuid1)>\" failed:"
-            "\n\tRequested attribute: 'attribute'"
-            "\n\tNo model element behind that attribute"
-            "\n\t--------"
+            "For model element \"<FakeModelObject 'Fake 1' (uuid1)>\" "
+            'attribute "attribute" is not set'
         )
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             link_serializer = link_converter.LinkSerializer(
                 base_object.pw.polarion_data_repo,
                 base_object.mc.converter_session,
@@ -507,7 +505,9 @@ class TestModelElements:
             links = link_serializer.create_links_for_work_item("uuid1")
 
         assert not links
-        assert caplog.messages[0] == expected
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == 20
+        assert caplog.records[0].message == expected
 
     @staticmethod
     def test_create_links_no_new_links_with_errors(


### PR DESCRIPTION
When the value behind `capella_attr` is `None`, then we shouldn't fail with an AssertionError. Now the logs are populated.