### PR TITLE
feat: Add `CAPELLA2POLARION_VERSION` to ci templates

### DIFF
--- a/ci-templates/gitlab/render_documents.yaml
+++ b/ci-templates/gitlab/render_documents.yaml
@@ -11,7 +11,7 @@ capella2polarion_render_documents:
     - job: capella2polarion_synchronise_elements
 
   script:
-    - pip install capella2polarion
+    - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
     - >
       python \
         -m capella2polarion \

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -10,7 +10,7 @@ capella2polarion_synchronise_elements:
       artifacts: true
 
   script:
-    - pip install capella2polarion
+    - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
     - >
       python \
         -m capella2polarion \


### PR DESCRIPTION
This PR adds a `CAPELLA2POLARION_VERSION` parameter to the gitlab ci-templates.