### PR TITLE
Add support for documents in separate projects, status filters and text work items

### DIFF
--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -171,7 +171,6 @@ def render_documents(
     for project, project_data in projects_document_data.items():
         polarion_worker.post_documents(project_data.new_docs, project)
         polarion_worker.update_documents(project_data.updated_docs, project)
-        polarion_worker.update_headings(project_data.work_items, project)
 
 
 if __name__ == "__main__":

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -169,7 +169,7 @@ def render_documents(
 
     projects_document_data = renderer.render_documents(configs, documents)
     for project, project_data in projects_document_data.items():
-        polarion_worker.post_documents(project_data.new_docs, project)
+        polarion_worker.create_documents(project_data.new_docs, project)
         polarion_worker.update_documents(project_data.updated_docs, project)
 
 

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -173,7 +173,7 @@ def render_documents(
 
     polarion_worker.post_documents(new_documents)
     polarion_worker.update_documents(updated_documents)
-    polarion_worker.update_work_items(work_items)
+    polarion_worker.update_headings(work_items)
 
 
 if __name__ == "__main__":

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -167,13 +167,11 @@ def render_documents(
         overwrite_layouts,
     )
 
-    new_documents, updated_documents, work_items = renderer.render_documents(
-        configs, documents
-    )
-
-    polarion_worker.post_documents(new_documents)
-    polarion_worker.update_documents(updated_documents)
-    polarion_worker.update_headings(work_items)
+    projects_document_data = renderer.render_documents(configs, documents)
+    for project, project_data in projects_document_data.items():
+        polarion_worker.post_documents(project_data.new_docs, project)
+        polarion_worker.update_documents(project_data.updated_docs, project)
+        polarion_worker.update_headings(project_data.work_items, project)
 
 
 if __name__ == "__main__":

--- a/capella2polarion/connectors/polarion_repo.py
+++ b/capella2polarion/connectors/polarion_repo.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import collections.abc as cabc
 
 import bidict
+import polarion_rest_api_client as polarion_api
 
 from capella2polarion import data_models
 
@@ -114,3 +115,15 @@ class PolarionDataRepository:
         for uuid in uuids:
             del self._work_items[uuid]
             del self._id_mapping[uuid]
+
+
+DocumentRepository = dict[
+    tuple[str | None, str, str],
+    tuple[polarion_api.Document | None, list[polarion_api.WorkItem]],
+]
+"""A dict providing a mapping for documents and their text workitems.
+
+It has (project, space, name) of the document as key and (document,
+workitems) as value. The project can be None and the None value means
+that the document is in the same project as the model sync work items.
+"""

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -15,11 +15,7 @@ from lxml import etree
 
 from capella2polarion import data_models
 from capella2polarion.connectors import polarion_repo
-from capella2polarion.converters import (
-    data_session,
-    document_config,
-    polarion_html_helper,
-)
+from capella2polarion.converters import data_session, polarion_html_helper
 
 logger = logging.getLogger(__name__)
 
@@ -496,17 +492,13 @@ class CapellaPolarionWorker:
         for document_data in document_datas:
             headings += document_data.headings
             documents.append(document_data.document)
-            if document_data.text_work_items:
-                text_work_item_type = next(
-                    iter(document_data.text_work_items.values())
-                ).type
+            if document_data.text_work_item_provider.new_text_work_items:
                 self._create_and_update_text_work_items(
-                    document_data.text_work_items, client
+                    document_data.text_work_item_provider.new_text_work_items,
+                    client,
                 )
-                polarion_html_helper.insert_text_work_items(
+                document_data.text_work_item_provider.insert_text_work_items(
                     document_data.document,
-                    document_data.text_work_items,
-                    text_work_item_type,
                 )
         return documents, headings
 
@@ -526,7 +518,7 @@ class CapellaPolarionWorker:
 
     def load_polarion_documents(
         self,
-        document_infos: t.Iterable[document_config.DocumentInfo],
+        document_infos: t.Iterable[data_models.DocumentInfo],
     ) -> dict[
         tuple[str | None, str, str],
         tuple[polarion_api.Document | None, list[polarion_api.WorkItem]],

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -152,12 +152,11 @@ class CapellaPolarionWorker:
                 work_items.append(wi)
             try:
                 self.project_client.work_items.delete(work_items)
-                self.polarion_data_repo.remove_work_items_by_capella_uuid(
-                    uuids
-                )
             except polarion_api.PolarionApiException as error:
                 logger.error("Deleting work items failed. %s", error.args[0])
                 raise error
+
+        self.polarion_data_repo.remove_work_items_by_capella_uuid(uuids)
 
     def create_missing_work_items(
         self, converter_session: data_session.ConverterSession

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -114,7 +114,7 @@ class CapellaPolarionWorker:
         """Return a map from Capella UUIDs to Polarion work items."""
         work_items = self.project_client.work_items.get_all(
             "HAS_VALUE:uuid_capella",
-            {"workitems": "id,uuid_capella,checksum,status,type"},
+            fields={"workitems": "id,uuid_capella,checksum,status,type"},
         )
         self.polarion_data_repo.update_work_items(work_items)
 

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -498,11 +498,12 @@ class CapellaPolarionWorker:
 
     def load_polarion_documents(
         self,
-        document_paths: t.Iterable[tuple[str, str]],
-        document_project: str | None = None,
-    ) -> dict[tuple[str, str], polarion_api.Document | None]:
+        document_paths: t.Iterable[tuple[str | None, str, str]],
+    ) -> dict[tuple[str | None, str, str], polarion_api.Document | None]:
         """Load the given document references from Polarion."""
         return {
-            (space, name): self.get_document(space, name, document_project)
-            for space, name in document_paths
+            (document_project, space, name): self.get_document(
+                space, name, document_project
+            )
+            for document_project, space, name in document_paths
         }

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -33,6 +33,7 @@ WORK_ITEMS_IN_PROJECT_QUERY = (
     "EXISTS (SELECT rel1.* FROM POLARION.REL_MODULE_WORKITEM rel1 WHERE "
     "rel1.FK_URI_MODULE = doc.C_URI AND rel1.FK_URI_WORKITEM = item.C_URI))"
 )
+"""An SQL query to get work items which are inserted in a given document."""
 
 
 class PolarionWorkerParams:
@@ -142,7 +143,7 @@ class CapellaPolarionWorker:
             if work_item.status != "deleted"
         }
         uuids: set[str] = existing_work_items - set(converter_session)
-        work_items: list[data_models.CapellaWorkitem] = []
+        work_items: list[data_models.CapellaWorkItem] = []
         for uuid in uuids:
             if wi := self.polarion_data_repo.get_work_item_by_capella_uuid(
                 uuid
@@ -527,7 +528,7 @@ class CapellaPolarionWorker:
         self, space: str, name: str, document_project: str | None = None
     ) -> polarion_api.Document | None:
         """Get a document from polarion and return None if not found.
-        
+
         Notes
         -----
         If the ``document_project`` is ``None`` the default client is
@@ -546,10 +547,7 @@ class CapellaPolarionWorker:
     def load_polarion_documents(
         self,
         document_infos: t.Iterable[data_models.DocumentInfo],
-    ) -> dict[
-        tuple[str | None, str, str],
-        tuple[polarion_api.Document | None, list[polarion_api.WorkItem]],
-    ]:
+    ) -> polarion_repo.DocumentRepository:
         """Load the documents referenced and text work items from Polarion."""
         return {
             (di.project_id, di.module_folder, di.module_name): (

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -15,7 +15,7 @@ from lxml import etree
 
 from capella2polarion import data_models
 from capella2polarion.connectors import polarion_repo
-from capella2polarion.converters import data_session, polarion_html_helper
+from capella2polarion.converters import data_session
 
 logger = logging.getLogger(__name__)
 
@@ -486,7 +486,11 @@ class CapellaPolarionWorker:
         client.work_items.update(headings)
         client.documents.update(documents)
 
-    def _process_document_datas(self, client, document_datas):
+    def _process_document_datas(
+        self,
+        client: polarion_api.ProjectClient,
+        document_datas: list[data_models.DocumentData],
+    ):
         documents = []
         headings = []
         for document_data in document_datas:

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -461,7 +461,7 @@ class CapellaPolarionWorker:
             if uuid in self.polarion_data_repo and data.work_item is not None:
                 self.compare_and_update_work_item(data)
 
-    def post_documents(
+    def create_documents(
         self,
         document_datas: list[data_models.DocumentData],
         document_project: str | None = None,

--- a/capella2polarion/converters/document_config.py
+++ b/capella2polarion/converters/document_config.py
@@ -1,7 +1,6 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Module with classes and a loader for document rendering configs."""
-import dataclasses
 import logging
 import pathlib
 import typing as t
@@ -12,20 +11,10 @@ import polarion_rest_api_client as polarion_api
 import pydantic
 import yaml
 
+from capella2polarion import data_models
 from capella2polarion.converters import polarion_html_helper
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class DocumentInfo:
-    """Class for information regarding a document which should be created."""
-
-    project_id: str | None
-    module_folder: str
-    module_name: str
-    text_work_item_type: str
-    text_work_item_id_field: str
 
 
 class WorkItemLayout(pydantic.BaseModel):
@@ -93,11 +82,11 @@ class DocumentConfigs(pydantic.BaseModel):
         pydantic.Field(default_factory=list)
     )
 
-    def iterate_documents(self) -> t.Iterator[DocumentInfo]:
+    def iterate_documents(self) -> t.Iterator[data_models.DocumentInfo]:
         """Yield all document paths of the config as tuples."""
         for conf in self.full_authority + self.mixed_authority:
             for inst in conf.instances:
-                yield DocumentInfo(
+                yield data_models.DocumentInfo(
                     project_id=conf.project_id,
                     module_folder=inst.polarion_space,
                     module_name=inst.polarion_name,

--- a/capella2polarion/converters/document_config.py
+++ b/capella2polarion/converters/document_config.py
@@ -47,6 +47,8 @@ class BaseDocumentRenderingConfig(pydantic.BaseModel):
     """A template config, which can result in multiple Polarion documents."""
 
     template_directory: str | pathlib.Path
+    project_id: str | None = None
+    status_allow_list: list[str] | None = None
     heading_numbering: bool = False
     work_item_layouts: dict[str, WorkItemLayout] = pydantic.Field(
         default_factory=dict
@@ -77,11 +79,11 @@ class DocumentConfigs(pydantic.BaseModel):
         pydantic.Field(default_factory=list)
     )
 
-    def iterate_documents(self) -> t.Iterator[tuple[str, str]]:
+    def iterate_documents(self) -> t.Iterator[tuple[str | None, str, str]]:
         """Yield all document paths of the config as tuples."""
         for conf in self.full_authority + self.mixed_authority:
             for inst in conf.instances:
-                yield inst.polarion_space, inst.polarion_name
+                yield conf.project_id, inst.polarion_space, inst.polarion_name
 
 
 def read_config_file(

--- a/capella2polarion/converters/document_renderer.py
+++ b/capella2polarion/converters/document_renderer.py
@@ -70,10 +70,7 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
         self.overwrite_heading_numbering = overwrite_heading_numbering
         self.overwrite_layouts = overwrite_layouts
         self.projects: dict[str | None, ProjectData] = {}
-        self.existing_documents: dict[
-            tuple[str | None, str, str],
-            tuple[polarion_api.Document | None, list[polarion_api.WorkItem]],
-        ] = {}
+        self.existing_documents: polarion_repo.DocumentRepository = {}
 
     def setup_env(self, env: jinja2.Environment):
         """Add globals and filters to the environment."""
@@ -354,10 +351,7 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
     def render_documents(
         self,
         configs: document_config.DocumentConfigs,
-        existing_documents: dict[
-            tuple[str | None, str, str],
-            tuple[polarion_api.Document | None, list[polarion_api.WorkItem]],
-        ],
+        existing_documents: polarion_repo.DocumentRepository,
     ) -> dict[str | None, ProjectData]:
         """Render all documents defined in the given config.
 

--- a/capella2polarion/converters/link_converter.py
+++ b/capella2polarion/converters/link_converter.py
@@ -13,10 +13,13 @@ import polarion_rest_api_client as polarion_api
 from capellambse.model import common
 from capellambse.model import diagram as diag
 
-import capella2polarion.converters.polarion_html_helper
 from capella2polarion import data_models
 from capella2polarion.connectors import polarion_repo
-from capella2polarion.converters import converter_config, data_session
+from capella2polarion.converters import (
+    converter_config,
+    data_session,
+    polarion_html_helper,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -346,9 +349,7 @@ def _group_by(
 def _make_url_list(link_map: dict[str, dict[str, list[str]]]) -> str:
     urls: list[str] = []
     for link_id in sorted(link_map):
-        url = capella2polarion.converters.polarion_html_helper.POLARION_WORK_ITEM_URL.format(  # pylint: disable=line-too-long
-            pid=link_id
-        )
+        url = polarion_html_helper.POLARION_WORK_ITEM_URL.format(pid=link_id)
         urls.append(f"<li>{url}</li>")
         for key, include_wids in link_map[link_id].items():
             _, display_name, _ = key.split(":")
@@ -365,9 +366,7 @@ def _sorted_unordered_html_list(
 ) -> str:
     urls: list[str] = []
     for pid in work_item_ids:
-        url = capella2polarion.converters.polarion_html_helper.POLARION_WORK_ITEM_URL.format(  # pylint: disable=line-too-long
-            pid=pid
-        )
+        url = polarion_html_helper.POLARION_WORK_ITEM_URL.format(pid=pid)
         urls.append(f"<li>{url}</li>")
 
     urls.sort()

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -114,7 +114,7 @@ class JinjaRendererMixin:
 
 
 def remove_table_ids(
-    html_content: str | list[html.HtmlComment],
+    html_content: str | list[html.HtmlElement],
 ) -> list[etree._Element]:
     """Remove the ID field from all tables.
 

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -123,7 +123,7 @@ def remove_table_ids(
     time the REST-API does not allow posting or patching a document with
     multiple tables having the same ID.
     """
-    html_fragments = _ensure_fragments(html_content)
+    html_fragments = ensure_fragments(html_content)
 
     for element in html_fragments:
         if element.tag == "table":
@@ -132,26 +132,27 @@ def remove_table_ids(
     return html_fragments
 
 
-def _ensure_fragments(
-    html_content: str | list[html.HtmlComment],
-) -> list[html.HtmlComment]:
+def ensure_fragments(
+    html_content: str | list[html.HtmlElement],
+) -> list[html.HtmlElement]:
+    """Convert string to html elements."""
     if isinstance(html_content, str):
         return html.fragments_fromstring(html_content)
     return html_content
 
 
-def extract_headings(html_content: str | list[html.HtmlComment]) -> list[str]:
+def extract_headings(html_content: str | list[html.HtmlElement]) -> list[str]:
     """Return a list of work item IDs for all headings in the given content."""
     return extract_work_items(html_content, h_regex)
 
 
 def extract_work_items(
-    html_content: str | list[html.HtmlComment],
+    html_content: str | list[html.HtmlElement],
     tag_regex: re.Pattern | None = None,
 ) -> list[str]:
     """Return a list of work item IDs for work items in the given content."""
     work_items = []
-    html_fragments = _ensure_fragments(html_content)
+    html_fragments = ensure_fragments(html_content)
     for element in html_fragments:
         if isinstance(element, html.HtmlComment):
             continue
@@ -177,7 +178,7 @@ def insert_text_work_items(
     layout_index = get_layout_index(
         "paragraph", document.rendering_layouts, text_work_item_type
     )
-    html_fragments = _ensure_fragments(document.home_page_content.value)
+    html_fragments = ensure_fragments(document.home_page_content.value)
     new_content = []
     last_match = -1
     for index, element in enumerate(html_fragments):

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -124,7 +124,7 @@ def remove_table_ids(
 
     for element in html_fragments:
         if element.tag == "table":
-            element.remove("id")
+            element.attrib.pop("id", None)
 
     return html_fragments
 

--- a/capella2polarion/converters/polarion_html_helper.py
+++ b/capella2polarion/converters/polarion_html_helper.py
@@ -165,44 +165,6 @@ def extract_work_items(
     return work_items
 
 
-def insert_text_work_items(
-    document: polarion_api.Document,
-    text_work_items: dict[str, polarion_api.WorkItem],
-    text_work_item_type: str,
-):
-    """Insert text work items into the given document."""
-    if not text_work_items:
-        return
-
-    assert document.home_page_content is not None
-    layout_index = get_layout_index(
-        "paragraph", document.rendering_layouts, text_work_item_type
-    )
-    html_fragments = ensure_fragments(document.home_page_content.value)
-    new_content = []
-    last_match = -1
-    for index, element in enumerate(html_fragments):
-        if isinstance(element, html.HtmlComment):
-            continue
-
-        if element.tag == "workitem":
-            new_content += html_fragments[last_match + 1 : index]
-            last_match = index
-            if work_item := text_work_items.get(element.get("id")):
-                new_content.append(
-                    html.fromstring(
-                        POLARION_WORK_ITEM_DOCUMENT.format(
-                            pid=work_item.id, lid=layout_index, custom_info=""
-                        )
-                    )
-                )
-
-    new_content += html_fragments[last_match + 1 :]
-    document.home_page_content.value = "\n".join(
-        [html.tostring(element).decode("utf-8") for element in new_content]
-    )
-
-
 def get_layout_index(
     default_layouter: str,
     rendering_layouts: list[polarion_api.RenderingLayout],

--- a/capella2polarion/converters/text_work_item_provider.py
+++ b/capella2polarion/converters/text_work_item_provider.py
@@ -90,6 +90,7 @@ class TextWorkItemProvider:
             return
 
         assert document.home_page_content is not None
+        assert document.rendering_layouts is not None
         layout_index = html_helper.get_layout_index(
             "paragraph", document.rendering_layouts, self.text_work_item_type
         )

--- a/capella2polarion/converters/text_work_item_provider.py
+++ b/capella2polarion/converters/text_work_item_provider.py
@@ -4,7 +4,7 @@
 import polarion_rest_api_client as polarion_api
 from lxml import html
 
-from capella2polarion.converters import polarion_html_helper
+from capella2polarion.converters import polarion_html_helper as html_helper
 
 
 class TextWorkItemProvider:
@@ -12,8 +12,8 @@ class TextWorkItemProvider:
 
     def __init__(
         self,
-        text_work_item_id_field: str = polarion_html_helper.TEXT_WORK_ITEM_ID_FIELD,
-        text_work_item_type: str = polarion_html_helper.TEXT_WORK_ITEM_TYPE,
+        text_work_item_id_field: str = html_helper.TEXT_WORK_ITEM_ID_FIELD,
+        text_work_item_type: str = html_helper.TEXT_WORK_ITEM_TYPE,
         existing_text_work_items: list[polarion_api.WorkItem] | None = None,
     ):
         self.old_text_work_items: dict[str, polarion_api.WorkItem] = {}
@@ -40,9 +40,9 @@ class TextWorkItemProvider:
         work_item_id_filter: list[str] | None = None,
     ):
         """Generate text work items from the provided html."""
-        content = polarion_html_helper.ensure_fragments(content)
+        content = html_helper.ensure_fragments(content)
         for element in content:
-            if element.tag != polarion_html_helper.WORK_ITEM_TAG:
+            if element.tag != html_helper.WORK_ITEM_TAG:
                 continue
 
             if not (text_id := element.get("id")):
@@ -88,10 +88,10 @@ class TextWorkItemProvider:
             return
 
         assert document.home_page_content is not None
-        layout_index = polarion_html_helper.get_layout_index(
+        layout_index = html_helper.get_layout_index(
             "paragraph", document.rendering_layouts, self.text_work_item_type
         )
-        html_fragments = polarion_html_helper.ensure_fragments(
+        html_fragments = html_helper.ensure_fragments(
             document.home_page_content.value
         )
         new_content = []
@@ -108,7 +108,7 @@ class TextWorkItemProvider:
                 ):
                     new_content.append(
                         html.fromstring(
-                            polarion_html_helper.POLARION_WORK_ITEM_DOCUMENT.format(
+                            html_helper.POLARION_WORK_ITEM_DOCUMENT.format(
                                 pid=work_item.id,
                                 lid=layout_index,
                                 custom_info="",

--- a/capella2polarion/converters/text_work_item_provider.py
+++ b/capella2polarion/converters/text_work_item_provider.py
@@ -1,0 +1,122 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Provides a class to generate and inset text work items in documents."""
+import polarion_rest_api_client as polarion_api
+from lxml import html
+
+from capella2polarion.converters import polarion_html_helper
+
+
+class TextWorkItemProvider:
+    """Class providing text work items, their generation and insertion."""
+
+    def __init__(
+        self,
+        text_work_item_id_field: str = polarion_html_helper.TEXT_WORK_ITEM_ID_FIELD,
+        text_work_item_type: str = polarion_html_helper.TEXT_WORK_ITEM_TYPE,
+        existing_text_work_items: list[polarion_api.WorkItem] | None = None,
+    ):
+        self.old_text_work_items: dict[str, polarion_api.WorkItem] = {}
+        for work_item in existing_text_work_items or []:
+            # We only use those work items which have an ID defined by us
+            if text_id := work_item.additional_attributes.get(
+                text_work_item_id_field
+            ):
+                if text_id in self.old_text_work_items:
+                    raise ValueError(
+                        f"There are multiple text work items with "
+                        f"{text_work_item_id_field} == {text_id}"
+                    )
+
+                self.old_text_work_items[text_id] = work_item
+
+        self.text_work_item_id_field = text_work_item_id_field
+        self.text_work_item_type = text_work_item_type
+        self.new_text_work_items: dict[str, polarion_api.WorkItem] = {}
+
+    def generate_text_work_items(
+        self,
+        content: list[html.HtmlElement] | str,
+        work_item_id_filter: list[str] | None = None,
+    ):
+        """Generate text work items from the provided html."""
+        content = polarion_html_helper.ensure_fragments(content)
+        for element in content:
+            if element.tag != polarion_html_helper.WORK_ITEM_TAG:
+                continue
+
+            if not (text_id := element.get("id")):
+                raise ValueError("All work items must have an ID in template")
+
+            if (
+                work_item_id_filter is None or text_id in work_item_id_filter
+            ) and text_id in self.old_text_work_items:
+                work_item = self.old_text_work_items[text_id]
+            else:
+                work_item = polarion_api.WorkItem(
+                    type=self.text_work_item_type,
+                    title="",
+                    status="open",
+                    additional_attributes={
+                        self.text_work_item_id_field: text_id
+                    },
+                )
+
+            work_item.description_type = "text/html"
+            inner_content = "".join(
+                [
+                    (
+                        html.tostring(child, encoding="unicode")
+                        if isinstance(child, html.HtmlElement)
+                        else child
+                    )
+                    for child in element.iterchildren()
+                ]
+            )
+            if element.text:
+                inner_content = element.text + inner_content
+
+            work_item.description = inner_content
+            self.new_text_work_items[text_id] = work_item
+
+    def insert_text_work_items(
+        self,
+        document: polarion_api.Document,
+    ):
+        """Insert text work items into the given document."""
+        if not self.new_text_work_items:
+            return
+
+        assert document.home_page_content is not None
+        layout_index = polarion_html_helper.get_layout_index(
+            "paragraph", document.rendering_layouts, self.text_work_item_type
+        )
+        html_fragments = polarion_html_helper.ensure_fragments(
+            document.home_page_content.value
+        )
+        new_content = []
+        last_match = -1
+        for index, element in enumerate(html_fragments):
+            if isinstance(element, html.HtmlComment):
+                continue
+
+            if element.tag == "workitem":
+                new_content += html_fragments[last_match + 1 : index]
+                last_match = index
+                if work_item := self.new_text_work_items.get(
+                    element.get("id")
+                ):
+                    new_content.append(
+                        html.fromstring(
+                            polarion_html_helper.POLARION_WORK_ITEM_DOCUMENT.format(
+                                pid=work_item.id,
+                                lid=layout_index,
+                                custom_info="",
+                            )
+                        )
+                    )
+
+        new_content += html_fragments[last_match + 1 :]
+        document.home_page_content.value = "\n".join(
+            [html.tostring(element).decode("utf-8") for element in new_content]
+        )

--- a/capella2polarion/converters/text_work_item_provider.py
+++ b/capella2polarion/converters/text_work_item_provider.py
@@ -100,7 +100,7 @@ class TextWorkItemProvider:
         new_content = []
         last_match = -1
         for index, element in enumerate(html_fragments):
-            if isinstance(element, html.HtmlComment):
+            if not isinstance(element, html.HtmlElement):
                 continue
 
             if element.tag == "workitem":

--- a/capella2polarion/converters/text_work_item_provider.py
+++ b/capella2polarion/converters/text_work_item_provider.py
@@ -48,11 +48,13 @@ class TextWorkItemProvider:
             if not (text_id := element.get("id")):
                 raise ValueError("All work items must have an ID in template")
 
-            if (
-                work_item_id_filter is None or text_id in work_item_id_filter
-            ) and text_id in self.old_text_work_items:
-                work_item = self.old_text_work_items[text_id]
-            else:
+            if not (
+                (work_item := self.old_text_work_items.get(text_id))
+                and (
+                    work_item_id_filter is None
+                    or work_item.id in work_item_id_filter
+                )
+            ):
                 work_item = polarion_api.WorkItem(
                     type=self.text_work_item_type,
                     title="",

--- a/capella2polarion/data_models.py
+++ b/capella2polarion/data_models.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import dataclasses
 import hashlib
 import json
 import typing as t
@@ -60,3 +61,16 @@ class CapellaWorkItem(polarion_api.WorkItem):
             | dict(sorted(attachment_checksums.items()))
         )
         return self._checksum
+
+
+@dataclasses.dataclass
+class DocumentData:
+    """A class to store data related to a rendered document."""
+
+    document: polarion_api.Document
+    headings: list[polarion_api.WorkItem] = dataclasses.field(
+        default_factory=list
+    )
+    text_work_items: dict[str, polarion_api.WorkItem] = dataclasses.field(
+        default_factory=dict
+    )

--- a/capella2polarion/data_models.py
+++ b/capella2polarion/data_models.py
@@ -11,6 +11,8 @@ import typing as t
 
 import polarion_rest_api_client as polarion_api
 
+from capella2polarion.converters import text_work_item_provider
+
 
 class CapellaWorkItem(polarion_api.WorkItem):
     """A WorkItem class with additional Capella related attributes."""
@@ -68,9 +70,16 @@ class DocumentData:
     """A class to store data related to a rendered document."""
 
     document: polarion_api.Document
-    headings: list[polarion_api.WorkItem] = dataclasses.field(
-        default_factory=list
-    )
-    text_work_items: dict[str, polarion_api.WorkItem] = dataclasses.field(
-        default_factory=dict
-    )
+    headings: list[polarion_api.WorkItem]
+    text_work_item_provider: text_work_item_provider.TextWorkItemProvider
+
+
+@dataclasses.dataclass
+class DocumentInfo:
+    """Class for information regarding a document which should be created."""
+
+    project_id: str | None
+    module_folder: str
+    module_name: str
+    text_work_item_type: str
+    text_work_item_id_field: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,3 +186,7 @@ def empty_polarion_worker(monkeypatch: pytest.MonkeyPatch):
         delete_work_items=True,
     )
     yield polarion_worker.CapellaPolarionWorker(polarion_params)
+
+
+DOCUMENT_TEMPLATES = TEST_DOCUMENT_ROOT / "templates"
+DOCUMENT_TEXT_WORK_ITEMS = "document_work_items.html.j2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,8 +128,10 @@ def base_object(
     )
 
     c2p_cli.setup_logger()
-    mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
-    monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
+    mock_api_client = mock.MagicMock(spec=polarion_api.PolarionClient)
+    monkeypatch.setattr(polarion_api, "PolarionClient", mock_api_client)
+    mock_project_client = mock.MagicMock(spec=polarion_api.ProjectClient)
+    monkeypatch.setattr(polarion_api, "ProjectClient", mock_project_client)
     c2p_cli.config = mock.Mock(converter_config.ConverterConfig)
 
     fake = FakeModelObject("uuid1", name="Fake 1")
@@ -173,8 +175,10 @@ def base_object(
 
 @pytest.fixture
 def empty_polarion_worker(monkeypatch: pytest.MonkeyPatch):
-    mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
-    monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
+    mock_api_client = mock.MagicMock(spec=polarion_api.PolarionClient)
+    monkeypatch.setattr(polarion_api, "PolarionClient", mock_api_client)
+    mock_project_client = mock.MagicMock(spec=polarion_api.ProjectClient)
+    monkeypatch.setattr(polarion_api, "ProjectClient", mock_project_client)
     polarion_params = polarion_worker.PolarionWorkerParams(
         project_id="project_id",
         url=TEST_HOST,

--- a/tests/data/documents/combined_config.yaml
+++ b/tests/data/documents/combined_config.yaml
@@ -37,6 +37,21 @@ mixed_authority:
         section_params:
           section1:
             param_1: Test
+  - template_directory: jupyter-notebooks/document_templates
+    sections:
+      section1: test-icd.html.j2
+      section2: test-icd.html.j2
+    heading_numbering: True
+    project_id: TestProject
+    status_allow_list:
+      - draft
+      - open
+    instances:
+      - polarion_space: _default
+        polarion_name: id1239
+        section_params:
+          section1:
+            param_1: Test
 full_authority:
   - template_directory: jupyter-notebooks/document_templates
     template: test-icd.html.j2
@@ -66,3 +81,14 @@ full_authority:
     instances:
       - polarion_space: _default
         polarion_name: id1238
+  - template_directory: jupyter-notebooks/document_templates
+    template: test-icd.html.j2
+    project_id: TestProject
+    status_allow_list:
+      - draft
+      - open
+    instances:
+      - polarion_space: _default
+        polarion_name: id1240
+        params:
+          interface: 2681f26a-e492-4e5d-8b33-92fb00a48622

--- a/tests/data/documents/full_authority_config.yaml
+++ b/tests/data/documents/full_authority_config.yaml
@@ -3,6 +3,10 @@
 
 - template_directory: jupyter-notebooks/document_templates
   template: test-icd.html.j2
+  project_id: TestProject
+  status_allow_list:
+    - draft
+    - open
   instances:
     - polarion_space: _default
       polarion_name: id123

--- a/tests/data/documents/mixed_config.yaml
+++ b/tests/data/documents/mixed_config.yaml
@@ -3,6 +3,10 @@
 
 mixed_authority:
   - template_directory: jupyter-notebooks/document_templates
+    project_id: TestProject
+    status_allow_list:
+      - draft
+      - open
     sections:
       section1: test-icd.html.j2
       section2: test-icd.html.j2

--- a/tests/data/documents/mixed_config.yaml
+++ b/tests/data/documents/mixed_config.yaml
@@ -25,6 +25,8 @@ mixed_authority:
       section1: test-icd.html.j2
       section2: test-icd.html.j2
     heading_numbering: True
+    text_work_item_type: myType
+    text_work_item_id_field: myId
     work_item_layouts:
       componentExchange:
         fields_at_start:

--- a/tests/data/documents/sections/section1.html.j2
+++ b/tests/data/documents/sections/section1.html.j2
@@ -6,3 +6,4 @@
 {{ heading(3, "New Heading", session) }}
 <p>{{ global_param }}</p>
 <p>{{ local_param }}</p>
+<workitem id="id1">TestContent</workitem>

--- a/tests/data/documents/sections/section2.html.j2
+++ b/tests/data/documents/sections/section2.html.j2
@@ -6,3 +6,4 @@
 {{ heading(3, "Keep Heading", session) }}
 <p>Overwritten: {{ global_param }}</p>
 <p>{{ local_param }}</p>
+<workitem id="id2">TestContent</workitem>

--- a/tests/data/documents/templates/document_work_items.html.j2
+++ b/tests/data/documents/templates/document_work_items.html.j2
@@ -1,0 +1,10 @@
+<!--
+ ~ Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+<workitem id="id1">This is Text in a text workitem</workitem>
+<workitem id="id2">
+<span>Text</span>
+<table><tr><td>1</td><td>2</td></tr></table>
+</workitem>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,11 +117,11 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         "get_document",
         mock_get_document,
     )
-    mock_post_documents = mock.MagicMock()
+    mock_create_documents = mock.MagicMock()
     monkeypatch.setattr(
         polarion_worker.CapellaPolarionWorker,
-        "post_documents",
-        mock_post_documents,
+        "create_documents",
+        mock_create_documents,
     )
     mock_update_documents = mock.MagicMock()
     monkeypatch.setattr(
@@ -161,11 +161,11 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         "TestProject",
     ]
 
-    assert mock_post_documents.call_count == 2
-    assert len(mock_post_documents.call_args_list[0].args[0]) == 1
-    assert len(mock_post_documents.call_args_list[1].args[0]) == 1
-    assert mock_post_documents.call_args_list[0].args[1] is None
-    assert mock_post_documents.call_args_list[1].args[1] == "TestProject"
+    assert mock_create_documents.call_count == 2
+    assert len(mock_create_documents.call_args_list[0].args[0]) == 1
+    assert len(mock_create_documents.call_args_list[1].args[0]) == 1
+    assert mock_create_documents.call_args_list[0].args[1] is None
+    assert mock_create_documents.call_args_list[1].args[1] == "TestProject"
 
     assert mock_update_documents.call_count == 2
     assert len(mock_update_documents.call_args_list[0].args[0]) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,10 +155,32 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
 
     assert result.exit_code == 0
     assert mock_get_polarion_wi_map.call_count == 1
-    assert mock_get_document.call_count == 6
-    assert mock_post_documents.call_count == 1
-    assert len(mock_post_documents.call_args.args[0]) == 1
-    assert mock_update_documents.call_count == 1
-    assert len(mock_update_documents.call_args.args[0]) == 1
-    assert mock_update_headings.call_count == 1
-    assert len(mock_update_headings.call_args.args[0]) == 1
+    assert mock_get_document.call_count == 8
+    assert [call.args[2] for call in mock_get_document.call_args_list] == [
+        None,
+        None,
+        None,
+        "TestProject",
+        None,
+        None,
+        None,
+        "TestProject",
+    ]
+
+    assert mock_post_documents.call_count == 2
+    assert len(mock_post_documents.call_args_list[0].args[0]) == 1
+    assert len(mock_post_documents.call_args_list[1].args[0]) == 1
+    assert mock_post_documents.call_args_list[0].args[1] is None
+    assert mock_post_documents.call_args_list[1].args[1] == "TestProject"
+
+    assert mock_update_documents.call_count == 2
+    assert len(mock_update_documents.call_args_list[0].args[0]) == 1
+    assert len(mock_update_documents.call_args_list[1].args[0]) == 0
+    assert mock_update_documents.call_args_list[0].args[1] is None
+    assert mock_update_documents.call_args_list[1].args[1] == "TestProject"
+
+    assert mock_update_headings.call_count == 2
+    assert len(mock_update_headings.call_args_list[0].args[0]) == 1
+    assert len(mock_update_headings.call_args_list[1].args[0]) == 0
+    assert mock_update_headings.call_args_list[0].args[1] is None
+    assert mock_update_headings.call_args_list[1].args[1] == "TestProject"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,12 +129,6 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         "update_documents",
         mock_update_documents,
     )
-    mock_update_headings = mock.MagicMock()
-    monkeypatch.setattr(
-        polarion_worker.CapellaPolarionWorker,
-        "update_headings",
-        mock_update_headings,
-    )
 
     command: list[str] = [
         "--polarion-project-id",
@@ -178,9 +172,3 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
     assert len(mock_update_documents.call_args_list[1].args[0]) == 0
     assert mock_update_documents.call_args_list[0].args[1] is None
     assert mock_update_documents.call_args_list[1].args[1] == "TestProject"
-
-    assert mock_update_headings.call_count == 2
-    assert len(mock_update_headings.call_args_list[0].args[0]) == 1
-    assert len(mock_update_headings.call_args_list[1].args[0]) == 0
-    assert mock_update_headings.call_args_list[0].args[1] is None
-    assert mock_update_headings.call_args_list[1].args[1] == "TestProject"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,8 +23,10 @@ from .conftest import (  # type: ignore[import]
 
 
 def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
-    mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
-    monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
+    mock_api_client = mock.MagicMock(spec=polarion_api.PolarionClient)
+    monkeypatch.setattr(polarion_api, "PolarionClient", mock_api_client)
+    mock_project_client = mock.MagicMock(spec=polarion_api.ProjectClient)
+    monkeypatch.setattr(polarion_api, "ProjectClient", mock_project_client)
     mock_get_polarion_wi_map = mock.MagicMock()
     monkeypatch.setattr(
         polarion_worker.CapellaPolarionWorker,
@@ -86,8 +88,10 @@ def test_migrate_model_elements(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_render_documents(monkeypatch: pytest.MonkeyPatch):
-    mock_api = mock.MagicMock(spec=polarion_api.OpenAPIPolarionProjectClient)
-    monkeypatch.setattr(polarion_api, "OpenAPIPolarionProjectClient", mock_api)
+    mock_api_client = mock.MagicMock(spec=polarion_api.PolarionClient)
+    monkeypatch.setattr(polarion_api, "PolarionClient", mock_api_client)
+    mock_project_client = mock.MagicMock(spec=polarion_api.ProjectClient)
+    monkeypatch.setattr(polarion_api, "ProjectClient", mock_project_client)
     mock_get_polarion_wi_map = mock.MagicMock()
     monkeypatch.setattr(
         polarion_worker.CapellaPolarionWorker,
@@ -95,7 +99,7 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         mock_get_polarion_wi_map,
     )
     mock_get_document = mock.MagicMock()
-    mock_get_document.side_effect = lambda folder, name: (
+    mock_get_document.side_effect = lambda folder, name, project_id: (
         polarion_api.Document(
             module_folder=folder,
             module_name=name,
@@ -125,11 +129,11 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
         "update_documents",
         mock_update_documents,
     )
-    mock_update_work_items = mock.MagicMock()
+    mock_update_headings = mock.MagicMock()
     monkeypatch.setattr(
         polarion_worker.CapellaPolarionWorker,
-        "update_work_items",
-        mock_update_work_items,
+        "update_headings",
+        mock_update_headings,
     )
 
     command: list[str] = [
@@ -156,5 +160,5 @@ def test_render_documents(monkeypatch: pytest.MonkeyPatch):
     assert len(mock_post_documents.call_args.args[0]) == 1
     assert mock_update_documents.call_count == 1
     assert len(mock_update_documents.call_args.args[0]) == 1
-    assert mock_update_work_items.call_count == 1
-    assert len(mock_update_work_items.call_args.args[0]) == 1
+    assert mock_update_headings.call_count == 1
+    assert len(mock_update_headings.call_args.args[0]) == 1

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -19,9 +19,11 @@ DOCUMENTS_CONFIG_JINJA = TEST_DOCUMENT_ROOT / "config.yaml.j2"
 MIXED_AUTHORITY_DOCUMENT = TEST_DOCUMENT_ROOT / "mixed_authority_doc.html"
 
 
-def existing_documents() -> dict[tuple[str, str], polarion_api.Document]:
+def existing_documents() -> (
+    dict[tuple[str | None, str, str], polarion_api.Document]
+):
     return {
-        ("_default", "id123"): polarion_api.Document(
+        (None, "_default", "id123"): polarion_api.Document(
             module_folder="_default",
             module_name="id123",
             home_page_content=polarion_api.TextContent(
@@ -34,7 +36,7 @@ def existing_documents() -> dict[tuple[str, str], polarion_api.Document]:
                 )
             ],
         ),
-        ("_default", "id1237"): polarion_api.Document(
+        (None, "_default", "id1237"): polarion_api.Document(
             module_folder="_default",
             module_name="id1237",
             home_page_content=polarion_api.TextContent(
@@ -289,6 +291,10 @@ def test_full_authority_document_config():
     assert conf.full_authority[0].instances[0].params == {
         "interface": "3d21ab4b-7bf6-428b-ba4c-a27bca4e86db"
     }
+    assert conf.full_authority[0].project_id == "TestProject"
+    assert conf.full_authority[0].status_allow_list == ["draft", "open"]
+    assert conf.full_authority[1].project_id is None
+    assert conf.full_authority[1].status_allow_list is None
 
 
 def test_mixed_authority_document_config():
@@ -308,6 +314,8 @@ def test_mixed_authority_document_config():
     assert len(conf.mixed_authority[0].instances) == 2
     assert conf.mixed_authority[0].instances[0].polarion_space == "_default"
     assert conf.mixed_authority[0].instances[0].polarion_name == "id123"
+    assert conf.mixed_authority[0].project_id == "TestProject"
+    assert conf.mixed_authority[0].status_allow_list == ["draft", "open"]
     assert conf.mixed_authority[0].instances[0].polarion_title == "Interface23"
     assert conf.mixed_authority[0].instances[0].params == {
         "interface": "3d21ab4b-7bf6-428b-ba4c-a27bca4e86db"
@@ -315,6 +323,8 @@ def test_mixed_authority_document_config():
     assert conf.mixed_authority[1].instances[0].section_params == {
         "section1": {"param_1": "Test"}
     }
+    assert conf.mixed_authority[1].project_id is None
+    assert conf.mixed_authority[1].status_allow_list is None
 
 
 def test_combined_config():

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -6,7 +6,7 @@ import pytest
 from lxml import etree, html
 
 from capella2polarion import data_models as dm
-from capella2polarion.connectors import polarion_worker
+from capella2polarion.connectors import polarion_repo, polarion_worker
 from capella2polarion.converters import (
     document_config,
     document_renderer,
@@ -28,10 +28,7 @@ DOCUMENTS_CONFIG_JINJA = TEST_DOCUMENT_ROOT / "config.yaml.j2"
 MIXED_AUTHORITY_DOCUMENT = TEST_DOCUMENT_ROOT / "mixed_authority_doc.html"
 
 
-def existing_documents() -> dict[
-    tuple[str | None, str, str],
-    tuple[polarion_api.Document, list[polarion_api.WorkItem]],
-]:
+def existing_documents() -> polarion_repo.DocumentRepository:
     return {
         (None, "_default", "id123"): (
             polarion_api.Document(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -231,7 +231,6 @@ def test_mixed_authority_document(
                 "global_param": "Overwrite global param",
             },
         },
-        {},
     )
 
     content: list[etree._Element] = html.fromstring(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -523,6 +523,10 @@ def test_mixed_authority_document_config():
     }
     assert conf.mixed_authority[1].project_id is None
     assert conf.mixed_authority[1].status_allow_list is None
+    assert conf.mixed_authority[0].text_work_item_type == "text"
+    assert conf.mixed_authority[0].text_work_item_id_field == "__C2P__id"
+    assert conf.mixed_authority[1].text_work_item_type == "myType"
+    assert conf.mixed_authority[1].text_work_item_id_field == "myId"
 
 
 def test_combined_config():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -795,7 +795,7 @@ class TestModelElements:
         assert base_object.pw.project_client.work_items.update.call_count == 1
         assert base_object.pw.project_client.work_items.get.call_count == 1
         assert (
-            base_object.pw.project_client.work_items.attachments.get_all.call_count
+            base_object.pw.project_client.work_items.attachments.get_all.call_count  # pylint: disable=line-too-long
             == 0
         )
         work_item = base_object.pw.project_client.work_items.update.call_args[
@@ -1017,7 +1017,7 @@ class TestModelElements:
             base_object.mc.converter_session
         )
         links = (
-            base_object.pw.project_client.work_items.links.get_all.call_args_list
+            base_object.pw.project_client.work_items.links.get_all.call_args_list  # pylint: disable=line-too-long
         )
         assert (
             base_object.pw.project_client.work_items.links.get_all.call_count

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -255,25 +255,18 @@ class TestDiagramElements:
         )
 
     @staticmethod
-    def test_create_diagrams_filters_non_diagram_elements(
-        diagr_base_object: BaseObjectContainer,
-    ):
-        # This test does not make any sense, but it also didn't before
-        pw = diagr_base_object.pw
-        diagr_base_object.mc.generate_work_items(pw.polarion_data_repo)
-        assert pw.client.generate_work_items.call_count == 0
-
-    @staticmethod
     def test_delete_diagrams(diagr_base_object: BaseObjectContainer):
         pw = diagr_base_object.pw
         diagr_base_object.mc.converter_session = {}
         diagr_base_object.mc.generate_work_items(pw.polarion_data_repo)
         pw.create_missing_work_items(diagr_base_object.mc.converter_session)
         pw.delete_orphaned_work_items(diagr_base_object.mc.converter_session)
-        assert pw.client is not None
-        assert pw.client.delete_work_items.call_count == 1
-        assert pw.client.delete_work_items.call_args[0][0] == ["Diag-1"]
-        assert pw.client.generate_work_items.call_count == 0
+        assert pw.project_client is not None
+        assert pw.project_client.work_items.delete.call_count == 1
+        assert pw.project_client.work_items.delete.call_args[0][0] == [
+            "Diag-1"
+        ]
+        assert pw.project_client.work_items.create.call_count == 0
 
 
 class TestModelElements:
@@ -755,8 +748,8 @@ class TestModelElements:
         polarion_api_get_all_work_items = mock.MagicMock()
         polarion_api_get_all_work_items.return_value = polarion_work_item_list
         monkeypatch.setattr(
-            base_object.pw.client,
-            "get_all_work_items",
+            base_object.pw.project_client.work_items,
+            "get_all",
             polarion_api_get_all_work_items,
         )
 
@@ -778,24 +771,35 @@ class TestModelElements:
         get_work_item_mock = mock.MagicMock()
         get_work_item_mock.return_value = polarion_work_item_list[0]
         monkeypatch.setattr(
-            base_object.pw.client,
-            "get_work_item",
+            base_object.pw.project_client.work_items,
+            "get",
             get_work_item_mock,
         )
 
         base_object.pw.compare_and_update_work_items(
             base_object.mc.converter_session
         )
-        assert base_object.pw.client is not None
-        assert base_object.pw.client.get_all_work_item_links.call_count == 0
-        assert base_object.pw.client.delete_work_item_links.call_count == 0
-        assert base_object.pw.client.create_work_item_links.call_count == 0
-        assert base_object.pw.client.update_work_item.call_count == 1
-        assert base_object.pw.client.get_work_item.call_count == 1
         assert (
-            base_object.pw.client.get_all_work_item_attachments.call_count == 0
+            base_object.pw.project_client.work_items.links.get_all.call_count
+            == 0
         )
-        work_item = base_object.pw.client.update_work_item.call_args[0][0]
+        assert (
+            base_object.pw.project_client.work_items.links.delete.call_count
+            == 0
+        )
+        assert (
+            base_object.pw.project_client.work_items.links.create.call_count
+            == 0
+        )
+        assert base_object.pw.project_client.work_items.update.call_count == 1
+        assert base_object.pw.project_client.work_items.get.call_count == 1
+        assert (
+            base_object.pw.project_client.work_items.attachments.get_all.call_count
+            == 0
+        )
+        work_item = base_object.pw.project_client.work_items.update.call_args[
+            0
+        ][0]
         assert isinstance(work_item, data_models.CapellaWorkItem)
         assert work_item.id == "Obj-1"
         assert work_item.title == "Fake 1"
@@ -821,8 +825,8 @@ class TestModelElements:
         polarion_api_get_all_work_items = mock.MagicMock()
         polarion_api_get_all_work_items.return_value = polarion_work_item_list
         monkeypatch.setattr(
-            base_object.pw.client,
-            "get_all_work_items",
+            base_object.pw.project_client.work_items,
+            "get_all",
             polarion_api_get_all_work_items,
         )
 
@@ -846,24 +850,26 @@ class TestModelElements:
         get_work_item_mock = mock.MagicMock()
         get_work_item_mock.return_value = polarion_work_item_list[0]
         monkeypatch.setattr(
-            base_object.pw.client,
-            "get_work_item",
+            base_object.pw.project_client.work_items,
+            "get",
             get_work_item_mock,
         )
         base_object.pw.delete_orphaned_work_items(
             base_object.mc.converter_session
         )
-        assert base_object.pw.client.update_work_item.called is False
+        assert base_object.pw.project_client.work_items.update.called is False
 
         base_object.pw.create_missing_work_items(
             base_object.mc.converter_session
         )
-        assert base_object.pw.client.create_work_items.called is False
+        assert base_object.pw.project_client.work_items.create.called is False
 
         base_object.pw.compare_and_update_work_items(
             base_object.mc.converter_session
         )
-        work_item = base_object.pw.client.update_work_item.call_args[0][0]
+        work_item = base_object.pw.project_client.work_items.update.call_args[
+            0
+        ][0]
         assert isinstance(work_item, data_models.CapellaWorkItem)
         assert work_item.status == "open"
 
@@ -897,8 +903,7 @@ class TestModelElements:
             base_object.mc.converter_session
         )
 
-        assert base_object.pw.client is not None
-        assert base_object.pw.client.update_work_item.call_count == 0
+        assert base_object.pw.project_client.work_items.update.call_count == 0
 
     @staticmethod
     def test_update_work_items_same_checksum_force(
@@ -931,8 +936,7 @@ class TestModelElements:
             base_object.mc.converter_session
         )
 
-        assert base_object.pw.client is not None
-        assert base_object.pw.client.update_work_item.call_count == 1
+        assert base_object.pw.project_client.work_items.update.call_count == 1
 
     @staticmethod
     def test_update_links_with_no_elements(base_object: BaseObjectContainer):
@@ -944,7 +948,10 @@ class TestModelElements:
             base_object.mc.converter_session
         )
 
-        assert base_object.pw.client.get_all_work_item_links.call_count == 0
+        assert (
+            base_object.pw.project_client.work_items.links.get_all.call_count
+            == 0
+        )
 
     @staticmethod
     def test_update_links(base_object: BaseObjectContainer):
@@ -980,8 +987,7 @@ class TestModelElements:
             )
         )
 
-        assert base_object.pw.client is not None
-        base_object.pw.client.get_all_work_item_links.side_effect = (
+        base_object.pw.project_client.work_items.links.get_all.side_effect = (
             [link],
             [],
         )
@@ -1001,7 +1007,7 @@ class TestModelElements:
         work_item_1.linked_work_items_truncated = True
         work_item_2.linked_work_items_truncated = True
 
-        base_object.pw.client.get_work_item.side_effect = (
+        base_object.pw.project_client.work_items.get.side_effect = (
             work_item_1,
             work_item_2,
         )
@@ -1009,19 +1015,31 @@ class TestModelElements:
         base_object.pw.compare_and_update_work_items(
             base_object.mc.converter_session
         )
-        assert base_object.pw.client is not None
-        links = base_object.pw.client.get_all_work_item_links.call_args_list
-        assert base_object.pw.client.get_all_work_item_links.call_count == 2
+        links = (
+            base_object.pw.project_client.work_items.links.get_all.call_args_list
+        )
+        assert (
+            base_object.pw.project_client.work_items.links.get_all.call_count
+            == 2
+        )
         assert [links[0][0][0], links[1][0][0]] == ["Obj-1", "Obj-2"]
-        new_links = base_object.pw.client.create_work_item_links.call_args[0][
-            0
-        ]
-        assert base_object.pw.client.create_work_item_links.call_count == 1
+        new_links = (
+            base_object.pw.project_client.work_items.links.create.call_args[0][
+                0
+            ]
+        )
+        assert (
+            base_object.pw.project_client.work_items.links.create.call_count
+            == 1
+        )
         assert new_links == [expected_new_link]
-        assert base_object.pw.client.delete_work_item_links.call_count == 1
-        assert base_object.pw.client.delete_work_item_links.call_args[0][
+        assert (
+            base_object.pw.project_client.work_items.links.delete.call_count
+            == 1
+        )
+        assert base_object.pw.project_client.work_items.links.delete.call_args[
             0
-        ] == [link]
+        ][0] == [link]
 
     @staticmethod
     def test_patch_work_item_grouped_links(
@@ -1095,9 +1113,8 @@ class TestModelElements:
         base_object.pw.compare_and_update_work_items(
             base_object.mc.converter_session
         )
-        assert base_object.pw.client is not None
         update_work_item_calls = (
-            base_object.pw.client.update_work_item.call_args_list
+            base_object.pw.project_client.work_items.update.call_args_list
         )
         assert len(update_work_item_calls) == 3
         mock_grouped_links_calls = mock_grouped_links.call_args_list

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -263,9 +263,10 @@ class TestDiagramElements:
         pw.delete_orphaned_work_items(diagr_base_object.mc.converter_session)
         assert pw.project_client is not None
         assert pw.project_client.work_items.delete.call_count == 1
-        assert pw.project_client.work_items.delete.call_args[0][0] == [
-            "Diag-1"
-        ]
+        assert (
+            pw.project_client.work_items.delete.call_args[0][0][0].id
+            == "Diag-1"
+        )
         assert pw.project_client.work_items.create.call_count == 0
 
 

--- a/tests/test_polarion_worker_documents.py
+++ b/tests/test_polarion_worker_documents.py
@@ -44,9 +44,8 @@ def test_update_document(
     document_data.text_work_item_provider.generate_text_work_items(
         document.home_page_content.value
     )
-    empty_polarion_worker.project_client.work_items.create.side_effect = (
-        _set_work_item_id
-    )
+    client = empty_polarion_worker.project_client
+    client.work_items.create.side_effect = _set_work_item_id
 
     empty_polarion_worker.update_documents([document_data])
 
@@ -56,47 +55,13 @@ def test_update_document(
         '<div id="polarion_wiki macro name=module-workitem;'
         'params=id=id0|layout=0|external=true"></div>'
     )
-    assert (
-        empty_polarion_worker.project_client.documents.update.call_count == 1
-    )
-    assert (
-        empty_polarion_worker.project_client.documents.update.call_args.args[0]
-        == [document]
-    )
-    assert (
-        empty_polarion_worker.project_client.work_items.create.call_count == 1
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.create.call_args.args[
-                0
-            ]
-        )
-        == 1
-    )
-    assert (
-        empty_polarion_worker.project_client.work_items.update.call_count == 2
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.update.call_args_list[
-                0
-            ].args[
-                0
-            ]
-        )
-        == 1
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.update.call_args_list[
-                1
-            ].args[
-                0
-            ]
-        )
-        == 0
-    )
+    assert client.documents.update.call_count == 1
+    assert client.documents.update.call_args.args[0] == [document]
+    assert client.work_items.create.call_count == 1
+    assert len(client.work_items.create.call_args.args[0]) == 1
+    assert client.work_items.update.call_count == 2
+    assert len(client.work_items.update.call_args_list[0].args[0]) == 1
+    assert len(client.work_items.update.call_args_list[1].args[0]) == 0
 
 
 def test_create_document(
@@ -123,9 +88,8 @@ def test_create_document(
     document_data.text_work_item_provider.generate_text_work_items(
         document.home_page_content.value
     )
-    empty_polarion_worker.project_client.work_items.create.side_effect = (
-        _set_work_item_id
-    )
+    client = empty_polarion_worker.project_client
+    client.work_items.create.side_effect = _set_work_item_id
 
     empty_polarion_worker.update_documents([document_data])
 
@@ -135,44 +99,10 @@ def test_create_document(
         '<div id="polarion_wiki macro name=module-workitem;'
         'params=id=id1|layout=0|external=true"></div>'
     )
-    assert (
-        empty_polarion_worker.project_client.documents.update.call_count == 1
-    )
-    assert (
-        empty_polarion_worker.project_client.documents.update.call_args.args[0]
-        == [document]
-    )
-    assert (
-        empty_polarion_worker.project_client.work_items.create.call_count == 1
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.create.call_args.args[
-                0
-            ]
-        )
-        == 2
-    )
-    assert (
-        empty_polarion_worker.project_client.work_items.update.call_count == 2
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.update.call_args_list[
-                0
-            ].args[
-                0
-            ]
-        )
-        == 0
-    )
-    assert (
-        len(
-            empty_polarion_worker.project_client.work_items.update.call_args_list[
-                1
-            ].args[
-                0
-            ]
-        )
-        == 0
-    )
+    assert client.documents.update.call_count == 1
+    assert client.documents.update.call_args.args[0] == [document]
+    assert client.work_items.create.call_count == 1
+    assert len(client.work_items.create.call_args.args[0]) == 2
+    assert client.work_items.update.call_count == 2
+    assert len(client.work_items.update.call_args_list[0].args[0]) == 0
+    assert len(client.work_items.update.call_args_list[1].args[0]) == 0

--- a/tests/test_polarion_worker_documents.py
+++ b/tests/test_polarion_worker_documents.py
@@ -1,0 +1,178 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import polarion_rest_api_client as polarion_api
+
+from capella2polarion import data_models
+from capella2polarion.connectors import polarion_worker
+from capella2polarion.converters import text_work_item_provider
+
+from .conftest import DOCUMENT_TEMPLATES, DOCUMENT_TEXT_WORK_ITEMS
+
+
+def _set_work_item_id(work_items: list[polarion_api.WorkItem]):
+    for index, work_item in enumerate(work_items):
+        work_item.id = f"id{index}"
+
+
+def test_update_document(
+    empty_polarion_worker: polarion_worker.CapellaPolarionWorker,
+):
+    path = DOCUMENT_TEMPLATES / DOCUMENT_TEXT_WORK_ITEMS
+    document = polarion_api.Document(
+        module_folder="_default",
+        module_name="TEST-DOC",
+        rendering_layouts=[],
+        home_page_content=polarion_api.TextContent(
+            type="text/html",
+            value=path.read_text("utf-8"),
+        ),
+    )
+    document_data = data_models.DocumentData(
+        document,
+        [],
+        text_work_item_provider.TextWorkItemProvider(
+            "MyField",
+            "MyType",
+            [
+                polarion_api.WorkItem(
+                    id="EXISTING", additional_attributes={"MyField": "id1"}
+                ),
+            ],
+        ),
+    )
+    document_data.text_work_item_provider.generate_text_work_items(
+        document.home_page_content.value
+    )
+    empty_polarion_worker.project_client.work_items.create.side_effect = (
+        _set_work_item_id
+    )
+
+    empty_polarion_worker.update_documents([document_data])
+
+    assert document.home_page_content.value.endswith(
+        '<div id="polarion_wiki macro name=module-workitem;'
+        'params=id=EXISTING|layout=0|external=true"></div>\n'
+        '<div id="polarion_wiki macro name=module-workitem;'
+        'params=id=id0|layout=0|external=true"></div>'
+    )
+    assert (
+        empty_polarion_worker.project_client.documents.update.call_count == 1
+    )
+    assert (
+        empty_polarion_worker.project_client.documents.update.call_args.args[0]
+        == [document]
+    )
+    assert (
+        empty_polarion_worker.project_client.work_items.create.call_count == 1
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.create.call_args.args[
+                0
+            ]
+        )
+        == 1
+    )
+    assert (
+        empty_polarion_worker.project_client.work_items.update.call_count == 2
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.update.call_args_list[
+                0
+            ].args[
+                0
+            ]
+        )
+        == 1
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.update.call_args_list[
+                1
+            ].args[
+                0
+            ]
+        )
+        == 0
+    )
+
+
+def test_create_document(
+    empty_polarion_worker: polarion_worker.CapellaPolarionWorker,
+):
+    path = DOCUMENT_TEMPLATES / DOCUMENT_TEXT_WORK_ITEMS
+    document = polarion_api.Document(
+        module_folder="_default",
+        module_name="TEST-DOC",
+        rendering_layouts=[],
+        home_page_content=polarion_api.TextContent(
+            type="text/html",
+            value=path.read_text("utf-8"),
+        ),
+    )
+    document_data = data_models.DocumentData(
+        document,
+        [],
+        text_work_item_provider.TextWorkItemProvider(
+            "MyField",
+            "MyType",
+        ),
+    )
+    document_data.text_work_item_provider.generate_text_work_items(
+        document.home_page_content.value
+    )
+    empty_polarion_worker.project_client.work_items.create.side_effect = (
+        _set_work_item_id
+    )
+
+    empty_polarion_worker.update_documents([document_data])
+
+    assert document.home_page_content.value.endswith(
+        '<div id="polarion_wiki macro name=module-workitem;'
+        'params=id=id0|layout=0|external=true"></div>\n'
+        '<div id="polarion_wiki macro name=module-workitem;'
+        'params=id=id1|layout=0|external=true"></div>'
+    )
+    assert (
+        empty_polarion_worker.project_client.documents.update.call_count == 1
+    )
+    assert (
+        empty_polarion_worker.project_client.documents.update.call_args.args[0]
+        == [document]
+    )
+    assert (
+        empty_polarion_worker.project_client.work_items.create.call_count == 1
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.create.call_args.args[
+                0
+            ]
+        )
+        == 2
+    )
+    assert (
+        empty_polarion_worker.project_client.work_items.update.call_count == 2
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.update.call_args_list[
+                0
+            ].args[
+                0
+            ]
+        )
+        == 0
+    )
+    assert (
+        len(
+            empty_polarion_worker.project_client.work_items.update.call_args_list[
+                1
+            ].args[
+                0
+            ]
+        )
+        == 0
+    )


### PR DESCRIPTION
In this PR the following additional Features will be added:
- Documents can now be placed in a different project than the model sync work items
- You can define a list of document statuses which you want to allow document updates in
- It is now possible to define text work items in a document
  - A text work item can be defined in the document template by using the workitem tag: `<workitem id="id">Some text</workitem>`
  - The defined ID must be unique in the document
  - The ID will be stored in a custom field of the work item in polarion
  - By default the type of these workitems is `text` and the ID will be stored in custom field `__C2P__id`
  - You can overwrite this in the config by setting the `text_work_item_type` and `text_work_item_id_field` parameters in your config:
```yaml
  - template_directory: jupyter-notebooks/document_templates
    sections:
      section1: test-icd.html.j2
      section2: test-icd.html.j2
    text_work_item_type: myType
    text_work_item_id_field: myId
    instances:
      - polarion_space: _default
        polarion_name: id1234
        section_params:
          section1:
            param_1: Test

```