### PR TITLE
fix: Keep existing rendering layouts in any case

### DIFF
--- a/capella2polarion/converters/document_renderer.py
+++ b/capella2polarion/converters/document_renderer.py
@@ -347,6 +347,19 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
             document, session.headings, text_work_item_provider
         )
 
+    def _update_rendering_layouts(
+        self,
+        document: polarion_api.Document,
+        rendering_layouts: list[polarion_api.RenderingLayout],
+    ):
+        """Keep existing work item layouts in their original order."""
+        document.rendering_layouts = document.rendering_layouts or []
+        for rendering_layout in rendering_layouts:
+            index = polarion_html_helper.get_layout_index(
+                "section", document.rendering_layouts, rendering_layout.type
+            )
+            document.rendering_layouts[index] = rendering_layout
+
     def _get_and_customize_doc(
         self,
         project_id: str | None,
@@ -359,11 +372,11 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
         old_doc, text_work_items = self.existing_documents.get(
             (project_id, space, name), (None, [])
         )
-        if old_doc:
+        if old_doc is not None:
             if title:
                 old_doc.title = title
             if self.overwrite_layouts:
-                old_doc.rendering_layouts = rendering_layouts
+                self._update_rendering_layouts(old_doc, rendering_layouts)
             if self.overwrite_heading_numbering:
                 old_doc.outline_numbering = heading_numbering
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -47,8 +47,11 @@ def existing_documents() -> polarion_repo.DocumentRepository:
                 ),
                 rendering_layouts=[
                     polarion_api.RenderingLayout(
+                        "text", "paragraph", type="text"
+                    ),
+                    polarion_api.RenderingLayout(
                         "Class", "paragraph", type="class"
-                    )
+                    ),
                 ],
             ),
             [],
@@ -461,7 +464,7 @@ def test_render_all_documents_partially_successfully(
     )
     assert (
         len(projects_data[None].updated_docs[1].document.rendering_layouts)
-        == 1
+        == 2
     )
     assert (
         projects_data[None].updated_docs[0].document.outline_numbering is None
@@ -540,7 +543,15 @@ def test_render_all_documents_overwrite_headings_layouts(
     updated_docs = projects_data[None].updated_docs
 
     assert len(updated_docs[0].document.rendering_layouts) == 2
-    assert len(updated_docs[1].document.rendering_layouts) == 2
+    assert len(updated_docs[1].document.rendering_layouts) == 3
+    assert updated_docs[1].document.rendering_layouts[0].type == "text"
+    assert updated_docs[1].document.rendering_layouts[1].type == "class"
+    assert (
+        "tree_view_diagram"
+        in updated_docs[1]
+        .document.rendering_layouts[1]
+        .properties.fields_at_end
+    )
     assert updated_docs[0].document.outline_numbering is False
     assert updated_docs[1].document.outline_numbering is False
 


### PR DESCRIPTION
Especially in mixed authority documents there might be work items outside the auto generated content. As these already refer a rendering layout, the order of the rendering layout must be kept as is even in the overwrite-layouts mode. Otherwise work items in non auto generated areas might use a wrong rendering layout and can look strange.