### PR TITLE
refactor!: Use envvar in CLI options

### DIFF
--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -22,13 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 @click.group()
-@click.option("--debug", is_flag=True, default=False)
+@click.option(
+    "--debug", is_flag=True, envvar="CAPELLA2POLARION_DEBUG", default=False
+)
 @click.option(
     "--polarion-project-id",
     type=str,
     required=False,
     default=None,
-    envvar="POLARION_PROJECT_ID",
+    envvar="CAPELLA2POLARION_PROJECT_ID",
 )
 @click.option(
     "--polarion-url",
@@ -36,8 +38,18 @@ logger = logging.getLogger(__name__)
     type=str,
 )
 @click.option("--polarion-pat", envvar="POLARION_PAT", type=str)
-@click.option("--polarion-delete-work-items", is_flag=True, default=False)
-@click.option("--capella-model", type=cli_helpers.ModelCLI(), default=None)
+@click.option(
+    "--polarion-delete-work-items",
+    is_flag=True,
+    envvar="CAPELLA2POLARION_DELETE_WORK_ITEMS",
+    default=False,
+)
+@click.option(
+    "--capella-model",
+    type=cli_helpers.ModelCLI(),
+    envvar="CAPELLA2POLARION_CAPELLA_MODEL",
+    default=None,
+)
 @click.pass_context
 def cli(
     ctx: click.core.Context,
@@ -76,11 +88,27 @@ def print_cli_state(capella2polarion_cli: Capella2PolarionCli) -> None:
 @click.option(
     "--synchronize-config",
     type=click.File(mode="r", encoding="utf8"),
+    envvar="CAPELLA2POLARION_SYNCHRONIZE_CONFIG",
     default=None,
 )
-@click.option("--force-update", is_flag=True, default=False)
-@click.option("--type-prefix", type=str, default="")
-@click.option("--role-prefix", type=str, default="")
+@click.option(
+    "--force-update",
+    is_flag=True,
+    envvar="CAPELLA2POLARION_FORCE_UPDATE",
+    default=False,
+)
+@click.option(
+    "--type-prefix",
+    type=str,
+    envvar="CAPELLA2POLARION_TYPE_PREFIX",
+    default="",
+)
+@click.option(
+    "--role-prefix",
+    type=str,
+    envvar="CAPELLA2POLARION_ROLE_PREFIX",
+    default="",
+)
 @click.pass_context
 def synchronize(
     ctx: click.core.Context,
@@ -133,10 +161,21 @@ def synchronize(
 @click.option(
     "--document-rendering-config",
     type=click.File(mode="r", encoding="utf8"),
+    envvar="CAPELLA2POLARION_DOCUMENT_CONFIG",
     default=None,
 )
-@click.option("--overwrite-layouts", is_flag=True, default=False)
-@click.option("--overwrite-numbering", is_flag=True, default=False)
+@click.option(
+    "--overwrite-layouts",
+    is_flag=True,
+    envvar="CAPELLA2POLARION_OVERWRITE_LAYOUTS",
+    default=False,
+)
+@click.option(
+    "--overwrite-numbering",
+    is_flag=True,
+    envvar="CAPELLA2POLARION_OVERWRITE_NUMBERING",
+    default=False,
+)
 @click.pass_context
 def render_documents(
     ctx: click.core.Context,

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -23,42 +23,42 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 @click.option(
-    "--debug", is_flag=True, envvar="CAPELLA2POLARION_DEBUG", default=False
+    "--capella-model",
+    type=cli_helpers.ModelCLI(),
+    required=True,
+    envvar="CAPELLA2POLARION_CAPELLA_MODEL",
 )
 @click.option(
     "--polarion-project-id",
     type=str,
-    required=False,
-    default=None,
+    required=True,
     envvar="CAPELLA2POLARION_PROJECT_ID",
 )
 @click.option(
     "--polarion-url",
-    envvar="POLARION_HOST",
     type=str,
+    required=True,
+    envvar="POLARION_HOST",
 )
-@click.option("--polarion-pat", envvar="POLARION_PAT", type=str)
+@click.option("--polarion-pat", type=str, required=True, envvar="POLARION_PAT")
 @click.option(
     "--polarion-delete-work-items",
     is_flag=True,
-    envvar="CAPELLA2POLARION_DELETE_WORK_ITEMS",
     default=False,
+    envvar="CAPELLA2POLARION_DELETE_WORK_ITEMS",
 )
 @click.option(
-    "--capella-model",
-    type=cli_helpers.ModelCLI(),
-    envvar="CAPELLA2POLARION_CAPELLA_MODEL",
-    default=None,
+    "--debug", is_flag=True, envvar="CAPELLA2POLARION_DEBUG", default=False
 )
 @click.pass_context
 def cli(
     ctx: click.core.Context,
-    debug: bool,
+    capella_model: capellambse.MelodyModel | None,
     polarion_project_id: str,
     polarion_url: str,
     polarion_pat: str,
     polarion_delete_work_items: bool,
-    capella_model: capellambse.MelodyModel | None,
+    debug: bool,
 ) -> None:
     """Synchronise data from Capella to Polarion."""
     if capella_model is not None and capella_model.diagram_cache is None:
@@ -88,8 +88,8 @@ def print_cli_state(capella2polarion_cli: Capella2PolarionCli) -> None:
 @click.option(
     "--synchronize-config",
     type=click.File(mode="r", encoding="utf8"),
+    required=True,
     envvar="CAPELLA2POLARION_SYNCHRONIZE_CONFIG",
-    default=None,
 )
 @click.option(
     "--force-update",
@@ -162,20 +162,20 @@ def synchronize(
 @click.option(
     "--document-rendering-config",
     type=click.File(mode="r", encoding="utf8"),
+    required=True,
     envvar="CAPELLA2POLARION_DOCUMENT_CONFIG",
-    default=None,
 )
 @click.option(
     "--overwrite-layouts",
     is_flag=True,
-    envvar="CAPELLA2POLARION_OVERWRITE_LAYOUTS",
     default=False,
+    envvar="CAPELLA2POLARION_OVERWRITE_LAYOUTS",
 )
 @click.option(
     "--overwrite-numbering",
     is_flag=True,
-    envvar="CAPELLA2POLARION_OVERWRITE_NUMBERING",
     default=False,
+    envvar="CAPELLA2POLARION_OVERWRITE_NUMBERING",
 )
 @click.pass_context
 def render_documents(

--- a/capella2polarion/__main__.py
+++ b/capella2polarion/__main__.py
@@ -58,10 +58,10 @@ def cli(
     polarion_url: str,
     polarion_pat: str,
     polarion_delete_work_items: bool,
-    capella_model: capellambse.MelodyModel,
+    capella_model: capellambse.MelodyModel | None,
 ) -> None:
     """Synchronise data from Capella to Polarion."""
-    if capella_model.diagram_cache is None:
+    if capella_model is not None and capella_model.diagram_cache is None:
         logger.warning("It's highly recommended to define a diagram cache!")
 
     capella2polarion_cli = Capella2PolarionCli(
@@ -128,6 +128,7 @@ def synchronize(
     )
     capella_to_polarion_cli.force_update = force_update
 
+    assert capella_to_polarion_cli.capella_model is not None
     converter = model_converter.ModelConverter(
         capella_to_polarion_cli.capella_model,
         capella_to_polarion_cli.polarion_params.project_id,
@@ -199,6 +200,7 @@ def render_documents(
         configs.iterate_documents()
     )
 
+    assert capella_to_polarion_cli.capella_model is not None
     renderer = document_renderer.DocumentRenderer(
         polarion_worker.polarion_data_repo,
         capella_to_polarion_cli.capella_model,

--- a/capella2polarion/cli.py
+++ b/capella2polarion/cli.py
@@ -26,7 +26,7 @@ class Capella2PolarionCli:
         polarion_url: str,
         polarion_pat: str,
         polarion_delete_work_items: bool,
-        capella_model: capellambse.MelodyModel,
+        capella_model: capellambse.MelodyModel | None,
         force_update: bool = False,
     ) -> None:
         self.debug = debug

--- a/ci-templates/gitlab/render_documents.yaml
+++ b/ci-templates/gitlab/render_documents.yaml
@@ -21,4 +21,4 @@ capella2polarion_render_documents:
 
   script:
     - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
-    - python -m capella2polarion render-documents
+    - capella2polarion render-documents

--- a/ci-templates/gitlab/render_documents.yaml
+++ b/ci-templates/gitlab/render_documents.yaml
@@ -3,6 +3,15 @@
 
 variables:
   CAPELLA2POLARION_DEBUG: "0"
+  # Remember to set the following environment variables:
+  # POLARION_HOST
+  # POLARION_PAT
+  # CAPELLA2POLARION_PROJECT_ID
+  # CAPELLA2POLARION_CAPELLA_MODEL
+  # CAPELLA2POLARION_DOCUMENT_CONFIG
+  # Optional flags:
+  # CAPELLA2POLARION_OVERWRITE_LAYOUTS - Overwrite default Live-Doc layouts
+  # CAPELLA2POLARION_OVERWRITE_NUMBERING - Overwrite default heading numbering
 
 capella2polarion_render_documents:
   needs:
@@ -12,13 +21,4 @@ capella2polarion_render_documents:
 
   script:
     - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
-    - >
-      python \
-        -m capella2polarion \
-        $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
-        --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
-        --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
-        render-documents \
-        $([[ $CAPELLA2POLARION_OVERWRITE_LAYOUTS -eq 1 ]] && echo '--overwrite-layouts') \
-        $([[ $CAPELLA2POLARION_OVERWRITE_NUMBERING -eq 1 ]] && echo '--overwrite-numbering') \
-        --document-rendering-config="${CAPELLA2POLARION_DOCUMENT_CONFIG:?}"
+    - python -m capella2polarion render-documents

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -3,6 +3,16 @@
 
 variables:
   CAPELLA2POLARION_DEBUG: "1"
+  # Remember to set the following environment variables:
+  # POLARION_HOST
+  # POLARION_PAT
+  # CAPELLA2POLARION_PROJECT_ID
+  # CAPELLA2POLARION_CAPELLA_MODEL
+  # CAPELLA2POLARION_SYNCHRONIZE_CONFIG
+  # Optional flags:
+  # CAPELLA2POLARION_FORCE_UPDATE - Simulate initial run
+  # CAPELLA2POLARION_TYPE_PREFIX - Prefix for work item types
+  # CAPELLA2POLARION_ROLE_PREFIX - Prefix for work item link roles
 
 capella2polarion_synchronise_elements:
   needs:
@@ -11,14 +21,4 @@ capella2polarion_synchronise_elements:
 
   script:
     - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
-    - >
-      python \
-        -m capella2polarion \
-        $([[ $CAPELLA2POLARION_DEBUG -eq 1 ]] && echo '--debug') \
-        --polarion-project-id=${CAPELLA2POLARION_PROJECT_ID:?} \
-        --capella-model="${CAPELLA2POLARION_MODEL_JSON:?}" \
-        synchronize \
-        --synchronize-config=${CAPELLA2POLARION_CONFIG:?} \
-        $([[ $CAPELLA2POLARION_FORCE_UPDATE -eq 1 ]] && echo '--force-update') \
-        ${CAPELLA2POLARION_TYPE_PREFIX:+--type-prefix="$CAPELLA2POLARION_TYPE_PREFIX"} \
-        ${CAPELLA2POLARION_ROLE_PREFIX:+--role-prefix="$CAPELLA2POLARION_ROLE_PREFIX"}
+    - python -m capella2polarion synchronize

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -21,4 +21,4 @@ capella2polarion_synchronise_elements:
 
   script:
     - pip install "capella2polarion${CAPELLA2POLARION_VERSION:+==$CAPELLA2POLARION_VERSION}"
-    - python -m capella2polarion synchronize
+    - capella2polarion synchronize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ test = [
   "pytest-cov",
 ]
 
+[project.scripts]
+capella2polarion = "capella2polarion.__main__:cli"
+
 [tool.black]
 line-length = 79
 target-version = ["py312"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,7 @@
 
 from __future__ import annotations
 
-import collections.abc as cabc
 import json
-import os
 import typing as t
 from unittest import mock
 
@@ -117,6 +115,7 @@ def cli_mocks(monkeypatch: pytest.MonkeyPatch) -> CLIMocks:
     )
 
 
+# pylint: disable=redefined-outer-name
 def test_migrate_model_elements(cli_mocks: CLIMocks):
     command: list[str] = [
         "--polarion-project-id",


### PR DESCRIPTION
The CLI usage was simplified by using `envvar`
on any flag or whenever possible.

Special thanks for the hint: @Wuestengecko 