### PR TITLE
feat: Limit document updates to relevant fields

### DIFF
--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -532,7 +532,12 @@ class CapellaPolarionWorker:
         client = self._get_client(document_project)
         try:
             return client.documents.get(
-                space, name, fields={"documents": "@all"}
+                space,
+                name,
+                fields={
+                    "documents": "renderingLayouts,homePageContent,status,"
+                    "moduleFolder,moduleName"
+                },
             )
         except polarion_api.PolarionApiBaseException as e:
             if e.args[0] == 404:

--- a/capella2polarion/converters/document_renderer.py
+++ b/capella2polarion/converters/document_renderer.py
@@ -390,6 +390,14 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
             (project_id, space, name), (None, [])
         )
         if old_doc is not None:
+            old_doc = polarion_api.Document(
+                id=old_doc.id,
+                module_folder=old_doc.module_folder,
+                module_name=old_doc.module_name,
+                status=old_doc.status,
+                home_page_content=old_doc.home_page_content,
+                rendering_layouts=old_doc.rendering_layouts,
+            )
             if title:
                 old_doc.title = title
             if self.overwrite_layouts:
@@ -422,16 +430,18 @@ class DocumentRenderer(polarion_html_helper.JinjaRendererMixin):
         document: polarion_api.Document,
         config: document_config.BaseDocumentRenderingConfig,
     ):
+        status = document.status
+        document.status = None
         if (
             config.status_allow_list is not None
-            and document.status not in config.status_allow_list
+            and status not in config.status_allow_list
         ):
             logger.warning(
                 "Won't update document %s/%s due to status "
                 "restrictions. Status is %s and should be in %r.",
                 document.module_folder,
                 document.module_name,
-                document.status,
+                status,
                 config.status_allow_list,
             )
             return False

--- a/ci-templates/gitlab/synchronise_elements.yml
+++ b/ci-templates/gitlab/synchronise_elements.yml
@@ -13,6 +13,8 @@ variables:
   # CAPELLA2POLARION_FORCE_UPDATE - Simulate initial run
   # CAPELLA2POLARION_TYPE_PREFIX - Prefix for work item types
   # CAPELLA2POLARION_ROLE_PREFIX - Prefix for work item link roles
+  # CAPELLA2POLARION_GENERATE_FIGURE_CAPTIONS - Generate captions for figures
+  # CAPELLA2POLARION_GROUPED_LINKS_CUSTOM_FIELDS - Generate custom fields for links grouped by role
 
 capella2polarion_synchronise_elements:
   needs:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -48,6 +48,7 @@ def existing_documents() -> polarion_repo.DocumentRepository:
                     type="text/html",
                     value=MIXED_AUTHORITY_DOCUMENT.read_text("utf-8"),
                 ),
+                outline_numbering_prefix="X",
                 rendering_layouts=[
                     polarion_api.RenderingLayout(
                         "text", "paragraph", type="text"
@@ -496,7 +497,7 @@ def test_render_all_documents_partially_successfully(
     # There are 8 documents in the config, we expect 4 rendering to fail
     assert len(caplog.records) == 4
     # The first tree documents weren't rendered due to an error, the fourth
-    # wasn't rendered because of status restrictions, which is a just warning
+    # wasn't rendered because of status restrictions, which is a warning
     assert [lr.levelno for lr in caplog.records] == [40, 40, 40, 30]
     # For one valid config we did not pass a document, so we expect a new one
     assert len(projects_data[None].new_docs) == 1
@@ -539,6 +540,20 @@ def test_render_all_documents_partially_successfully(
     )
     assert (
         projects_data[None].updated_docs[1].document.outline_numbering is None
+    )
+    assert not any(
+        doc.document.status is not None
+        for doc in (
+            projects_data[None].updated_docs
+            + projects_data["TestProject"].updated_docs
+        )
+    )
+    assert not any(
+        doc.document.outline_numbering_prefix is not None
+        for doc in (
+            projects_data[None].updated_docs
+            + projects_data["TestProject"].updated_docs
+        )
     )
 
 


### PR DESCRIPTION
Currently we always send all fields we received from the server with the patch request back to the server. When a user performs changes during the document rendering, it is possible that these custom fields get overwritten by capella2polarion with outdated data. While we cannot guarantee that we don't overwrite content changes made during the rendering, it's easy to avoid overwriting data, we do not actually change in Capella2Polarion. For that reason we will only send `homePageContent`, `renderingLayouts` and optionally `title` and `outlineNumbering` in patch requests in the future.