### PR TITLE
Use Requirement.identifier as fallback display ID

### DIFF
--- a/capella2polarion/converters/element_converter.py
+++ b/capella2polarion/converters/element_converter.py
@@ -421,7 +421,7 @@ class CapellaWorkItemSerializer(polarion_html_helper.JinjaRendererMixin):
 
             if not (req.type and req.text):
                 identifier = (
-                    req.long_name or req.name or req.summary or req.uuid
+                    req.long_name or req.name or req.identifier or req.uuid
                 )
                 self.converter_session[obj.uuid].errors.add(
                     f"Found Requirement without text or type on {identifier!r}"


### PR DESCRIPTION
'summary' isn't actually a supported attribute for Requirement objects, and therefore will never be non-empty. Use 'identifier' instead.