### PR TITLE
Use an obviously broken attribute name for the test

### DIFF
--- a/tests/data/model_elements/config.yaml
+++ b/tests/data/model_elements/config.yaml
@@ -71,7 +71,7 @@ sa:
           - EX_ITEMS_OR_EXCH # functional exchange or exchange item name
   FunctionalExchange:
     links:
-      - exchanged_items
+      - broken_attribute_name
   ExchangeItem:
 
 pa:

--- a/tests/test_converter_config.py
+++ b/tests/test_converter_config.py
@@ -57,7 +57,7 @@ class TestConverterConfig:
             "Global link parent is not available on Capella type diagram",
             "capella2polarion.converters.converter_config",
             40,
-            "Link exchanged_items is not available on Capella type "
+            "Link broken_attribute_name is not available on Capella type "
             "FunctionalExchange",
         )
         with open(TEST_MODEL_ELEMENTS_CONFIG, "r", encoding="utf8") as f:


### PR DESCRIPTION
Instead of a minimal typo of an existing name, use an attribute name that makes it obvious that it's supposed to be broken.

Some more context: In the upstream Capella metamodel, the attribute is actually called `exchangedItems`, while capellambse for some reason I don't remember uses `exchange_items`. I intend to unify the spelling of this name (and some others with similar issues) in the not-too-distant future, which would fail `tests/test_converter_config.py::TestConverterConfig::test_read_config_links`, since the "unknown attribute" warning would no longer be emitted.