### PR TITLE
Update project infrastructure

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -10,6 +10,10 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_type == 'tag' && github.sha || '0' }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test with Python ${{matrix.python_version}} on ${{matrix.os}}
@@ -25,22 +29,26 @@ jobs:
           - "3.13"
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+        with:
+          fetch-depth: 0
+          filter: tree:0
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
           python-version: ${{matrix.python_version}}
       - name: Run unit tests
-        run: uv run coverage run
-      - name: Report coverage
-        if: always()
-        run: uv run coverage report
+        run: |-
+          uv run -m pytest --cov-report=term --cov=capella2polarion --rootdir=.
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+        with:
+          fetch-depth: 0
+          filter: tree:0
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -55,7 +63,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+          filter: tree:0
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,10 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_type == 'tag' && github.sha || '0' }}
+  cancel-in-progress: true
+
 jobs:
   sphinx:
     runs-on: ubuntu-latest
@@ -18,7 +22,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+          filter: tree:0
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -49,7 +49,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
 cover/
@@ -74,7 +74,6 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/source/code/
-docs/source/_build
 
 # PyBuilder
 .pybuilder/
@@ -86,9 +85,6 @@ target/
 # IPython
 profile_default/
 ipython_config.py
-
-# uv
-uv.lock
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
@@ -102,20 +98,35 @@ uv.lock
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
+#poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -129,6 +140,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -159,6 +171,12 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
 
 # VSCode
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_stages: [pre-commit, pre-merge-commit]
 minimum_pre_commit_version: 4.0.0
 repos:
   - repo: https://github.com/gitleaks/gitleaks.git
-    rev: v8.24.3
+    rev: v8.28.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -82,41 +82,50 @@ repos:
           - LICENSES/.license_header_apache.txt
           - --comment-style
           - '..|  |'
-  - repo: https://github.com/PyCQA/docformatter
-    rev: eb1df347edd128b30cd3368dddc3aa65edcfac38 # Don't autoupdate until https://github.com/PyCQA/docformatter/issues/293 is fixed
+  - repo: local # docformatter
     hooks:
       - id: docformatter
-        additional_dependencies:
-          - docformatter[tomli]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+        name: docformatter
+        language: system
+        entry: uv run --dev docformatter --in-place
+        types_or: [python]
+        require_serial: true
+  - repo: local # ruff
     hooks:
-      - id: ruff
-        args: [--extend-ignore=FIX, --fix]
       - id: ruff-format
+        name: Format with ruff
+        language: system
+        entry: uv run --dev ruff format
+        types_or: [python, pyi, jupyter]
+        require_serial: true
+      - id: ruff-check
+        name: Lint with ruff
+        language: system
+        entry: uv run --dev ruff check
+        args: [--extend-ignore=FIX, --fix]
+        types_or: [python, pyi, jupyter]
+        require_serial: true
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
       - id: actionlint-docker
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+  - repo: local # mypy
     hooks:
       - id: mypy
-        additional_dependencies:
-          - bidict
-          - cairosvg
-          - capellambse==0.6.6
-          - click
-          - jinja2
-          - polarion-rest-api-client==1.2.0
-          - pydantic
-          - types-requests
-          - types-PyYAML
-        exclude: tests
-  - repo: https://github.com/fsfe/reuse-tool
-    rev: v5.0.2
+        name: mypy
+        language: system
+        entry: uv run --dev mypy
+        args: [capella2polarion, --scripts-are-modules]
+        types_or: [python, pyi, toml, yaml]
+        require_serial: true
+        pass_filenames: false
+  - repo: local # reuse
     hooks:
       - id: reuse
+        name: reuse
+        language: system
+        entry: uv run --dev reuse lint-file
+        require_serial: true
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,6 @@ The key differences are:
   writing `from typing import SomeName`, use `import typing as t` and access
   typing related classes like `t.TypedDict`.
 
-  <!-- prettier-ignore -->
-
   Use the new syntax and classes for typing introduced with Python 3.10.
 
   - Instead of `t.Tuple`, `t.List` etc. use the builtin classes `tuple`, `list`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Use cases covered:
 
 # Documentation
 
-<!-- prettier-ignore -->
 Read the [full documentation on GitHub](https://dsd-dbs.github.io/capella-polarion).
 
 # Installation

--- a/capella2polarion/__init__.py
+++ b/capella2polarion/__init__.py
@@ -6,6 +6,6 @@ from importlib import metadata
 
 try:
     __version__ = metadata.version("capella2polarion")
-except metadata.PackageNotFoundError:
+except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0+unknown"
 del metadata

--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -172,7 +172,9 @@ class CapellaPolarionWorker:
         ]
         if missing_work_items:
             try:
-                self.project_client.work_items.create(missing_work_items)
+                self.project_client.work_items.create(
+                    t.cast(list[polarion_api.WorkItem], missing_work_items)
+                )
                 self.polarion_data_repo.update_work_items(missing_work_items)
             except polarion_api.PolarionApiException as error:
                 logger.error("Creating work items failed. %s", error.args[0])

--- a/capella2polarion/documents/text_work_item_provider.py
+++ b/capella2polarion/documents/text_work_item_provider.py
@@ -37,12 +37,14 @@ class TextWorkItemProvider:
 
     def generate_text_work_items(
         self,
-        content: list[html.HtmlElement] | str,
+        content: list[html.HtmlElement | str],
         work_item_id_filter: list[str] | None = None,
     ) -> None:
         """Generate text work items from the provided html."""
         content = html_helper.ensure_fragments(content)
         for element in content:
+            # FIXME what if content[0] is str?
+            assert not isinstance(element, str)
             if element.tag != html_helper.WORK_ITEM_TAG:
                 continue
 
@@ -121,5 +123,7 @@ class TextWorkItemProvider:
 
         new_content += html_fragments[last_match + 1 :]
         document.home_page_content.value = "\n".join(
-            [html.tostring(element).decode("utf-8") for element in new_content]
+            html.tostring(element).decode("utf-8")
+            for element in new_content
+            if isinstance(element, html.HtmlElement)
         )

--- a/capella2polarion/elements/converter_config.py
+++ b/capella2polarion/elements/converter_config.py
@@ -15,6 +15,8 @@ import yaml
 from capellambse import model as m
 from capellambse_context_diagrams import filters as context_filters
 
+from . import element_converter
+
 logger = logging.getLogger(__name__)
 
 _C2P_DEFAULT = "_C2P_DEFAULT"
@@ -63,8 +65,9 @@ class LinkConfig:
                     reverse_field=None,
                 )
             elif isinstance(link, dict):
+                lid: str = link["capella_attr"]
                 config = LinkConfig(
-                    capella_attr=(lid := link["capella_attr"]),
+                    capella_attr=lid,
                     polarion_role=add_prefix(
                         link.get("polarion_role", lid),
                         role_prefix,
@@ -474,8 +477,6 @@ def merge_converters(
 @functools.cache
 def _get_valid_converters() -> frozenset[str]:
     """Return valid converters from CapellaWorkItemSerializer."""
-    from . import element_converter
-
     valid_converters = set()
     serializer_cls = element_converter.CapellaWorkItemSerializer
     for name, member in inspect.getmembers(serializer_cls):

--- a/capella2polarion/elements/model_converter.py
+++ b/capella2polarion/elements/model_converter.py
@@ -180,11 +180,12 @@ class ModelConverter:
                 )
 
 
-def get_layer_name(diagram: m.Diagram) -> str:
+def get_layer_name(diagram: m.AbstractDiagram) -> str:
     """Return the layer name for a diagram."""
     if diagram.type.name in ["EAB", "CIBD"]:
         return "epbs"
 
+    assert isinstance(diagram.target, m.ModelElement)
     match diagram.target.layer:
         case diagram._model.oa:
             return "oa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,23 +49,29 @@ capella2polarion = "capella2polarion.__main__:cli"
 
 [dependency-groups]
 dev = [
-  "coverage>=7.6.9",
-  "pre-commit>=4.0.1",
+  "coverage>=7.9.1",
+  "docformatter[tomli]==1.7.7",
+  "mypy==1.16.1",
+  "pre-commit>=4.2.0",
   "pre-commit-uv>=4.1.4",
-  "pytest>=8.3.4",
-  "python-dotenv",
-  "ruff>=0.8.2",
+  "pytest>=8.4.1",
+  "pytest-cov>=6.2.1",
+  "python-dotenv>=1.1.0",
+  "reuse==5.0.2",
+  "ruff==0.12.0",
   "types-lxml>=2025.3.30",
+  "types-pyyaml>=6.0.12.20250516",
+  "types-requests>=2.32.4.20250611",
 ]
 
 docs = [
   "furo>=2024.8.6",
   "ipython>=8.30.0",
   "nbsphinx>=0.9.5",
-  "python-dotenv",
+  "python-dotenv>=1.1.0",
+  "sphinx>=8.1.3",
   "sphinx-copybutton>=0.5.2",
-  "sphinx>=8.1.3,<8.2.0",                # Fixated until https://github.com/spatialaudio/nbsphinx/issues/825 is solved
-  "tomli>=2.2.1; python_version<'3.11'",
+  "tomli>=2.2.1 ; python_full_version < '3.11'",
 ]
 
 [tool.coverage.run]
@@ -98,13 +104,12 @@ python_version = "3.10"
 
 [[tool.mypy.overrides]]
 # Untyped third party libraries
-module = [
-  # ...
-]
+module = ["cairosvg"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = """
+  -W error::pytest.PytestUnraisableExceptionWarning
   --import-mode=importlib
   --strict-config
   --strict-markers


### PR DESCRIPTION
I marked @ewuerger as Co-author because I cherry-picked out of ed6e2569. Let me know if you don't want that.

This PR pulls in the changes from our latest cookiecutter. Most notable is the updated pre-commit setup, which calls hooks via `uv run` in the dev environment, thereby preventing hook dependencies from going out of sync with the ones declared in pyproject.toml (which is what ed6e2569 tried to address in the first place).