### PR TITLE
Fix project URLs on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dbinfrago/capella2polarion"
-Documentation = "https://dbinfrago.github.io/capella2polarion"
+Homepage = "https://github.com/dbinfrago/capella-polarion"
+Documentation = "https://dbinfrago.github.io/capella-polarion"
 
 [project.scripts]
 capella2polarion = "capella2polarion.__main__:cli"


### PR DESCRIPTION
This fixes the links in the sidebar on PyPI to point to the correct Github repository name 'capella-polarion' instead of 'capella2polarion'.