### PR TITLE
Update polarion-rest-api-client to 1.4.3

### DIFF
--- a/capella2polarion/connectors/polarion_worker.py
+++ b/capella2polarion/connectors/polarion_worker.py
@@ -347,7 +347,7 @@ class CapellaPolarionWorker:
 
         if new.description:
             new.description.value = chelpers.process_html_fragments(
-                new.description.value, set_attachment_id
+                new.description.value or "", set_attachment_id
             )
         for _, attributes in new.additional_attributes.items():
             if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "click",
   "python-datauri>=3.0.2,<4",
   "jinja2",
-  "polarion-rest-api-client==1.4.1",
+  "polarion-rest-api-client==1.4.3",
   "pydantic",
   "pyyaml",
 ]


### PR DESCRIPTION
This update ensures compatibility with Python 3.13.